### PR TITLE
Allow overriding the token used in the CLI app by setting environment…

### DIFF
--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -55,7 +55,7 @@ impl Authentication {
     }
 
     pub fn read_token() -> Result<String, AuthenticationError> {
-          if let Ok(token) = env::var("API_TOKEN") { println!("API_TOKEN {}", token);
+          if let Ok(token) = env::var("API_TOKEN") {
              return Ok(token)
           }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Logins with the token and stores it for further use if it's valid
+    /// Logins with the token and stores it for further use if it's valid. You can set API_TOKEN environment variable to override used API token.
     Login { token: String },
     /// Screen related commands
     #[command(subcommand)]


### PR DESCRIPTION
… variable.

## What does this PR do?
Allows using API_TOKEN environment variable to set the API token. This is convenient in docker scripts so we don't have to do the login command there and store the token.

## GitHub issue or Phabricator ticket number?
None
## How has this been tested?
There are unit tests
## Checklist before merging

- [x] If have added tests.
- [x] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
