### PR TITLE
Support "-j" output option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 anyhow = "1.0.65"
 clap = { version = "4.0.17", features = ["derive"] }
 envtestkit = "1.1.2"
+humantime = "2.1.0"
 log = { version = "0.4.17", features = ["release_max_level_info", "max_level_trace"] }
 prettytable-rs = "0.9.0"
 reqwest = { version = "0.11.12", features = ["json", "blocking"] }
@@ -20,6 +21,7 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 simple_logger = "3.0.0"
 tempdir = "0.3.7"
+term = "0.7.0"
 thiserror = "1.0.37"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.65"
 clap = { version = "4.0.17", features = ["derive"] }
 envtestkit = "1.1.2"
 log = { version = "0.4.17", features = ["release_max_level_info", "max_level_trace"] }
+prettytable-rs = "0.9.0"
 reqwest = { version = "0.11.12", features = ["json", "blocking"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Screenly Command Line Interface (CLI)
 
-The purpose of Screenly's CLI is to make developer's life easier. Using our CLI, users are able to quickly interact with Screenly through their terminal. Morover, this CLI is built such that it can be used for automating tasks.
+The purpose of Screenly's CLI is to make developer's life easier. Using our CLI, users are able to quickly interact with Screenly through their terminal. Moreover, this CLI is built such that it can be used for automating tasks.
 
 # Building
 

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -41,9 +41,7 @@ impl Config {
 
     #[cfg(test)]
     pub fn new(url: String) -> Self {
-        Self {
-            url,
-        }
+        Self { url }
     }
 }
 
@@ -55,9 +53,9 @@ impl Authentication {
     }
 
     pub fn read_token() -> Result<String, AuthenticationError> {
-          if let Ok(token) = env::var("API_TOKEN") {
-             return Ok(token)
-          }
+        if let Ok(token) = env::var("API_TOKEN") {
+            return Ok(token);
+        }
 
         match env::var("HOME") {
             Ok(path) => {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,7 @@
 use crate::{Authentication, AuthenticationError};
 
-
+use humantime::format_duration;
+use std::time::Duration;
 use thiserror::Error;
 
 use prettytable::{row, Table};
@@ -43,12 +44,13 @@ impl Formatter for Screens {
             OutputType::HumanReadable => {
                 let mut table = Table::new();
                 table.add_row(row!(
+                    b =>
                     "Id",
                     "Name",
-                    "Hardware version",
-                    "In sync",
-                    "Last ping",
-                    "Uptime (seconds)"
+                    "Hardware Version",
+                    "In Sync",
+                    "Last Ping",
+                    "Uptime"
                 ));
 
                 if !self.value.is_array() {
@@ -57,13 +59,32 @@ impl Formatter for Screens {
 
                 if let Some(screens) = self.value.as_array() {
                     for screen in screens {
+                        let formatted_uptime = if let Some(uptime) = screen["uptime"].as_str() {
+                            if uptime.eq("N/A") {
+                                uptime.to_owned()
+                            } else {
+                                format_duration(Duration::new(
+                                    uptime.parse::<f64>().unwrap_or(0.0) as u64,
+                                    0,
+                                ))
+                                .to_string()
+                            }
+                        } else {
+                            "N/A".to_owned()
+                        };
+
                         table.add_row(row!(
-                            screen["id"].as_str().unwrap_or("n/a"),
-                            screen["name"].as_str().unwrap_or("n/a"),
-                            screen["hardware_version"].as_str().unwrap_or("n/a"),
-                            screen["in_sync"].as_bool().unwrap_or(false),
-                            screen["last_ping"].as_str().unwrap_or("n/a"),
-                            screen["uptime"].as_str().unwrap_or("n/a"),
+                            screen["id"].as_str().unwrap_or("N/A"),
+                            screen["name"].as_str().unwrap_or("N/A"),
+                            screen["hardware_version"].as_str().unwrap_or("N/A"),
+                            // converting to &str just to make sure they are capitalized
+                            if screen["in_sync"].as_bool().unwrap_or(false) {
+                                "True"
+                            } else {
+                                "False"
+                            },
+                            screen["last_ping"].as_str().unwrap_or("N/A"),
+                            formatted_uptime,
                         ));
                     }
                 }
@@ -202,16 +223,16 @@ mod tests {
     #[test]
     fn test_format_when_human_readable_output_is_set_should_return_correct_formatted_string() {
         let screen = Screens::new(serde_json::from_str("[{\"id\":\"017a5104-524b-33d8-8026-9087b59e7eb5\",\"team_id\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"created_at\":\"2021-06-28T05:07:55+00:00\",\"name\":\"Renat's integrated wired NM\",\"is_enabled\":true,\"coords\":[55.22931, 48.90429],\"last_ping\":\"2021-08-25T06:17:20.728+00:00\",\"last_ip\":null,\"local_ip\":\"192.168.1.146\",\"mac\":\"b8:27:eb:d6:83:6f\",\"last_screenshot_time\":\"2021-08-25T06:09:04.399+00:00\",\"uptime\":\"230728.38\",\"load_avg\":\"0.14\",\"signal_strength\":null,\"interface\":\"eth0\",\"debug\":false,\"location\":\"Kamsko-Ust'inskiy rayon, Russia\",\"team\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"timezone\":\"Europe/Moscow\",\"type\":\"hardware\",\"hostname\":\"srly-4shnfrdc5cd2p0p\",\"ws_open\":false,\"status\":\"Offline\",\"last_screenshot\":\"https://us-assets.screenlyapp.com/01CD1W50NR000A28F31W83B1TY/screenshots/01F98G8MJB6FC809MGGYTSWZNN/5267668e6db35498e61b83d4c702dbe8\",\"in_sync\":false,\"software_version\":\"Screenly 2 Player\",\"hardware_version\":\"Raspberry Pi 3B\",\"config\":{\"hdmi_mode\": 34, \"hdmi_boost\": 2, \"hdmi_drive\": 0, \"hdmi_group\": 0, \"verify_ssl\": true, \"audio_output\": \"hdmi\", \"hdmi_timings\": \"\", \"overscan_top\": 0, \"overscan_left\": 0, \"use_composite\": false, \"display_rotate\": 0, \"overscan_right\": 0, \"overscan_scale\": 0, \"overscan_bottom\": 0, \"disable_overscan\": 0, \"shuffle_playlist\": false, \"framebuffer_width\": 0, \"use_composite_pal\": false, \"framebuffer_height\": 0, \"hdmi_force_hotplug\": true, \"use_composite_ntsc\": false, \"hdmi_pixel_encoding\": 0, \"play_history_enabled\": false}}, {\"id\":\"017a5104-524b-33d8-8026-9087b59e7eb6\",\"team_id\":\"016343c2-82b8-0000-a121-e30f1035875d\",\"created_at\":\"2020-06-28T05:07:55+00:00\",\"name\":\"Not Renat's integrated wired NM\",\"is_enabled\":true,\"coords\":[55.22931, 48.90429],\"last_ping\":\"2020-08-25T06:17:20.728+00:00\",\"last_ip\":null,\"local_ip\":\"192.168.1.146\",\"mac\":\"b8:27:eb:d6:83:6f\",\"last_screenshot_time\":\"2021-08-25T06:09:04.399+00:00\",\"uptime\":\"230728.38\",\"load_avg\":\"0.14\",\"signal_strength\":null,\"interface\":\"eth0\",\"debug\":false,\"location\":\"Kamsko-Ust'inskiy rayon, Russia\",\"team\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"timezone\":\"Europe/Moscow\",\"type\":\"hardware\",\"hostname\":\"srly-4shnfrdc5cd2p0p\",\"ws_open\":false,\"status\":\"Offline\",\"last_screenshot\":\"https://us-assets.screenlyapp.com/01CD1W50NR000A28F31W83B1TY/screenshots/01F98G8MJB6FC809MGGYTSWZNN/5267668e6db35498e61b83d4c702dbe8\",\"in_sync\":false,\"software_version\":\"Screenly 2 Player\",\"hardware_version\":\"Raspberry Pi 3B\",\"config\":{\"hdmi_mode\": 34, \"hdmi_boost\": 2, \"hdmi_drive\": 0, \"hdmi_group\": 0, \"verify_ssl\": true, \"audio_output\": \"hdmi\", \"hdmi_timings\": \"\", \"overscan_top\": 0, \"overscan_left\": 0, \"use_composite\": false, \"display_rotate\": 0, \"overscan_right\": 0, \"overscan_scale\": 0, \"overscan_bottom\": 0, \"disable_overscan\": 0, \"shuffle_playlist\": false, \"framebuffer_width\": 0, \"use_composite_pal\": false, \"framebuffer_height\": 0, \"hdmi_force_hotplug\": true, \"use_composite_ntsc\": false, \"hdmi_pixel_encoding\": 0, \"play_history_enabled\": false}}]").unwrap());
-
+        println!("{}", screen.format(OutputType::HumanReadable));
         let expected_output = concat!(
 "+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n",
-"| Id                                   | Name                            | Hardware version | In sync | Last ping                     | Uptime (seconds) |\n",
+"| Id                                   | Name                            | Hardware Version | In Sync | Last Ping                     | Uptime           |\n",
 "+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n",
-"| 017a5104-524b-33d8-8026-9087b59e7eb5 | Renat's integrated wired NM     | Raspberry Pi 3B  | false   | 2021-08-25T06:17:20.728+00:00 | 230728.38        |\n",
+"| 017a5104-524b-33d8-8026-9087b59e7eb5 | Renat's integrated wired NM     | Raspberry Pi 3B  | False   | 2021-08-25T06:17:20.728+00:00 | 2days 16h 5m 28s |\n",
 "+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n",
-"| 017a5104-524b-33d8-8026-9087b59e7eb6 | Not Renat's integrated wired NM | Raspberry Pi 3B  | false   | 2020-08-25T06:17:20.728+00:00 | 230728.38        |\n",
-"+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n");
-
+"| 017a5104-524b-33d8-8026-9087b59e7eb6 | Not Renat's integrated wired NM | Raspberry Pi 3B  | False   | 2020-08-25T06:17:20.728+00:00 | 2days 16h 5m 28s |\n",
+"+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n"
+);
         assert_eq!(screen.format(OutputType::HumanReadable), expected_output);
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,9 +1,9 @@
 use crate::{Authentication, AuthenticationError};
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+
+
 use thiserror::Error;
 
-use prettytable::{row, Cell, Row, Table};
+use prettytable::{row, Table};
 
 pub enum OutputType {
     HumanReadable,
@@ -58,12 +58,12 @@ impl Formatter for Screens {
                 if let Some(screens) = self.value.as_array() {
                     for screen in screens {
                         table.add_row(row!(
-                            screen["id"].as_str().unwrap_or_else(|| "n/a"),
-                            screen["name"].as_str().unwrap_or_else(|| "n/a"),
-                            screen["hardware_version"].as_str().unwrap_or_else(|| "n/a"),
-                            screen["in_sync"].as_bool().unwrap_or_else(|| false),
-                            screen["last_ping"].as_str().unwrap_or_else(|| "n/a"),
-                            screen["uptime"].as_str().unwrap_or_else(|| "n/a"),
+                            screen["id"].as_str().unwrap_or("n/a"),
+                            screen["name"].as_str().unwrap_or("n/a"),
+                            screen["hardware_version"].as_str().unwrap_or("n/a"),
+                            screen["in_sync"].as_bool().unwrap_or(false),
+                            screen["last_ping"].as_str().unwrap_or("n/a"),
+                            screen["uptime"].as_str().unwrap_or("n/a"),
                         ));
                     }
                 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,18 @@
 use crate::{Authentication, AuthenticationError};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use thiserror::Error;
 
-use serde_json::Value;
+use prettytable::{row, Cell, Row, Table};
+
+pub enum OutputType {
+    HumanReadable,
+    Json,
+}
+
+pub trait Formatter {
+    fn format(&self, output_type: OutputType) -> String;
+}
 
 #[derive(Error, Debug)]
 pub enum CommandError {
@@ -15,73 +25,66 @@ pub enum CommandError {
     #[error("unknown error #[0]")]
     WrongResponseStatus(u16),
 }
-// TODO: Use in the future no need to deserialize for current features
-#[derive(Debug, Deserialize, Serialize, Default)]
-pub struct ScreenConfig {}
-// TODO: Use in the future no need to deserialize for current features
-#[derive(Deserialize, Serialize, Debug, Default)]
-pub struct Screen {
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub team_id: Option<String>,
-    #[serde(default)]
-    pub created_at: Option<String>,
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub is_enabled: bool,
-    #[serde(default)]
-    pub last_ping: Option<String>,
-    #[serde(default)]
-    pub last_ip: Option<String>,
-    #[serde(default)]
-    pub local_ip: Option<String>,
-    #[serde(default)]
-    pub mac: Option<String>,
-    #[serde(default)]
-    pub last_screenshot_time: Option<String>,
-    #[serde(default)]
-    pub uptime: Option<String>,
-    #[serde(default)]
-    pub load_avg: Option<String>,
-    #[serde(default)]
-    pub signal_strength: Option<i32>,
-    #[serde(default)]
-    pub interface: Option<String>,
-    #[serde(default)]
-    pub debug: bool,
-    #[serde(default)]
-    pub location: Option<String>,
-    #[serde(default)]
-    pub team: Option<String>,
-    #[serde(default)]
-    pub timezone: Option<String>,
-    #[serde(default)]
-    pub hostname: Option<String>,
-    #[serde(default)]
-    pub ws_open: bool,
-    #[serde(default)]
-    pub status: Option<String>,
-    #[serde(default)]
-    pub last_screenshot: Option<String>,
-    #[serde(default)]
-    pub in_sync: bool,
-    #[serde(default)]
-    pub software_version: Option<String>,
-    #[serde(default)]
-    pub hardware_version: Option<String>,
-    #[serde(default)]
-    pub config: ScreenConfig,
+
+#[derive(Debug)]
+pub struct Screens {
+    pub value: serde_json::Value,
 }
+
+impl Screens {
+    pub fn new(value: serde_json::Value) -> Self {
+        Self { value }
+    }
+}
+
+impl Formatter for Screens {
+    fn format(&self, output_type: OutputType) -> String {
+        match output_type {
+            OutputType::HumanReadable => {
+                let mut table = Table::new();
+                table.add_row(row!(
+                    "Id",
+                    "Name",
+                    "Hardware version",
+                    "In sync",
+                    "Last ping",
+                    "Uptime (seconds)"
+                ));
+
+                if !self.value.is_array() {
+                    return "".to_owned();
+                }
+
+                if let Some(screens) = self.value.as_array() {
+                    for screen in screens {
+                        table.add_row(row!(
+                            screen["id"].as_str().unwrap_or_else(|| "n/a"),
+                            screen["name"].as_str().unwrap_or_else(|| "n/a"),
+                            screen["hardware_version"].as_str().unwrap_or_else(|| "n/a"),
+                            screen["in_sync"].as_bool().unwrap_or_else(|| false),
+                            screen["last_ping"].as_str().unwrap_or_else(|| "n/a"),
+                            screen["uptime"].as_str().unwrap_or_else(|| "n/a"),
+                        ));
+                    }
+                }
+                table.to_string()
+            }
+            OutputType::Json => {
+                serde_json::to_string_pretty(&self.value).unwrap_or_else(|_| "{}".to_string())
+            }
+        }
+    }
+}
+
 pub struct ScreenCommand {
     authentication: Authentication,
 }
+
 impl ScreenCommand {
     pub fn new(authentication: Authentication) -> Self {
         Self { authentication }
     }
-    pub fn list(&self) -> anyhow::Result<Value, CommandError> {
+    pub fn list(&self) -> anyhow::Result<Screens, CommandError> {
         let url = self.authentication.config.url.clone() + "/v4/screens";
         let response = self.authentication.build_client()?.get(url).send()?;
         if response.status().as_u16() != 200 {
@@ -89,10 +92,10 @@ impl ScreenCommand {
                 response.status().as_u16(),
             ));
         }
-        serde_json::from_str(&response.text().unwrap_or_else(|_| "{}".to_owned()))
-            .map_err(CommandError::ParseError)
+        Ok(Screens::new(serde_json::from_str(&response.text()?)?))
     }
-    pub fn get(&self, id: &str) -> anyhow::Result<Value, CommandError> {
+
+    pub fn get(&self, id: &str) -> anyhow::Result<Screens, CommandError> {
         let url = self.authentication.config.url.clone() + "/v4/screens?id=eq." + id;
         let response = self.authentication.build_client()?.get(url).send()?;
         if response.status().as_u16() != 200 {
@@ -101,15 +104,14 @@ impl ScreenCommand {
             ));
         }
 
-        serde_json::from_str(&response.text().unwrap_or_else(|_| "{}".to_owned()))
-            .map_err(CommandError::ParseError)
+        Ok(Screens::new(serde_json::from_str(&response.text()?)?))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::authentication::Config;
-    use crate::Authentication;
+    use crate::{Authentication, Formatter, OutputType};
     use httpmock::{Method::GET, MockServer};
 
     use envtestkit::lock::lock_test;
@@ -117,7 +119,7 @@ mod tests {
     use std::ffi::OsString;
     use std::fs;
 
-    use crate::commands::ScreenCommand;
+    use crate::commands::{ScreenCommand, Screens};
     use serde_json::Value;
     use tempdir::TempDir;
 
@@ -143,7 +145,7 @@ mod tests {
         let screen_command = ScreenCommand::new(authentication);
         let expected = serde_json::from_str::<Value>("[{\"id\":\"017a5104-524b-33d8-8026-9087b59e7eb5\",\"team_id\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"created_at\":\"2021-06-28T05:07:55+00:00\",\"name\":\"Renat's integrated wired NM\",\"is_enabled\":true,\"coords\":[55.22931, 48.90429],\"last_ping\":\"2021-08-25T06:17:20.728+00:00\",\"last_ip\":null,\"local_ip\":\"192.168.1.146\",\"mac\":\"b8:27:eb:d6:83:6f\",\"last_screenshot_time\":\"2021-08-25T06:09:04.399+00:00\",\"uptime\":\"230728.38\",\"load_avg\":\"0.14\",\"signal_strength\":null,\"interface\":\"eth0\",\"debug\":false,\"location\":\"Kamsko-Ust'inskiy rayon, Russia\",\"team\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"timezone\":\"Europe/Moscow\",\"type\":\"hardware\",\"hostname\":\"srly-4shnfrdc5cd2p0p\",\"ws_open\":false,\"status\":\"Offline\",\"last_screenshot\":\"https://us-assets.screenlyapp.com/01CD1W50NR000A28F31W83B1TY/screenshots/01F98G8MJB6FC809MGGYTSWZNN/5267668e6db35498e61b83d4c702dbe8\",\"in_sync\":false,\"software_version\":\"Screenly 2 Player\",\"hardware_version\":\"Raspberry Pi 3B\",\"config\":{\"hdmi_mode\": 34, \"hdmi_boost\": 2, \"hdmi_drive\": 0, \"hdmi_group\": 0, \"verify_ssl\": true, \"audio_output\": \"hdmi\", \"hdmi_timings\": \"\", \"overscan_top\": 0, \"overscan_left\": 0, \"use_composite\": false, \"display_rotate\": 0, \"overscan_right\": 0, \"overscan_scale\": 0, \"overscan_bottom\": 0, \"disable_overscan\": 0, \"shuffle_playlist\": false, \"framebuffer_width\": 0, \"use_composite_pal\": false, \"framebuffer_height\": 0, \"hdmi_force_hotplug\": true, \"use_composite_ntsc\": false, \"hdmi_pixel_encoding\": 0, \"play_history_enabled\": false}}]").unwrap();
         let v = screen_command.list().unwrap();
-        assert_eq!(v, expected);
+        assert_eq!(v.value, expected);
     }
 
     #[test]
@@ -194,6 +196,22 @@ mod tests {
         let v = screen_command
             .get("017a5104-524b-33d8-8026-9087b59e7eb5")
             .unwrap();
-        assert_eq!(v, expected);
+        assert_eq!(v.value, expected);
+    }
+
+    #[test]
+    fn test_format_when_human_readable_output_is_set_should_return_correct_formatted_string() {
+        let screen = Screens::new(serde_json::from_str("[{\"id\":\"017a5104-524b-33d8-8026-9087b59e7eb5\",\"team_id\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"created_at\":\"2021-06-28T05:07:55+00:00\",\"name\":\"Renat's integrated wired NM\",\"is_enabled\":true,\"coords\":[55.22931, 48.90429],\"last_ping\":\"2021-08-25T06:17:20.728+00:00\",\"last_ip\":null,\"local_ip\":\"192.168.1.146\",\"mac\":\"b8:27:eb:d6:83:6f\",\"last_screenshot_time\":\"2021-08-25T06:09:04.399+00:00\",\"uptime\":\"230728.38\",\"load_avg\":\"0.14\",\"signal_strength\":null,\"interface\":\"eth0\",\"debug\":false,\"location\":\"Kamsko-Ust'inskiy rayon, Russia\",\"team\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"timezone\":\"Europe/Moscow\",\"type\":\"hardware\",\"hostname\":\"srly-4shnfrdc5cd2p0p\",\"ws_open\":false,\"status\":\"Offline\",\"last_screenshot\":\"https://us-assets.screenlyapp.com/01CD1W50NR000A28F31W83B1TY/screenshots/01F98G8MJB6FC809MGGYTSWZNN/5267668e6db35498e61b83d4c702dbe8\",\"in_sync\":false,\"software_version\":\"Screenly 2 Player\",\"hardware_version\":\"Raspberry Pi 3B\",\"config\":{\"hdmi_mode\": 34, \"hdmi_boost\": 2, \"hdmi_drive\": 0, \"hdmi_group\": 0, \"verify_ssl\": true, \"audio_output\": \"hdmi\", \"hdmi_timings\": \"\", \"overscan_top\": 0, \"overscan_left\": 0, \"use_composite\": false, \"display_rotate\": 0, \"overscan_right\": 0, \"overscan_scale\": 0, \"overscan_bottom\": 0, \"disable_overscan\": 0, \"shuffle_playlist\": false, \"framebuffer_width\": 0, \"use_composite_pal\": false, \"framebuffer_height\": 0, \"hdmi_force_hotplug\": true, \"use_composite_ntsc\": false, \"hdmi_pixel_encoding\": 0, \"play_history_enabled\": false}}, {\"id\":\"017a5104-524b-33d8-8026-9087b59e7eb6\",\"team_id\":\"016343c2-82b8-0000-a121-e30f1035875d\",\"created_at\":\"2020-06-28T05:07:55+00:00\",\"name\":\"Not Renat's integrated wired NM\",\"is_enabled\":true,\"coords\":[55.22931, 48.90429],\"last_ping\":\"2020-08-25T06:17:20.728+00:00\",\"last_ip\":null,\"local_ip\":\"192.168.1.146\",\"mac\":\"b8:27:eb:d6:83:6f\",\"last_screenshot_time\":\"2021-08-25T06:09:04.399+00:00\",\"uptime\":\"230728.38\",\"load_avg\":\"0.14\",\"signal_strength\":null,\"interface\":\"eth0\",\"debug\":false,\"location\":\"Kamsko-Ust'inskiy rayon, Russia\",\"team\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"timezone\":\"Europe/Moscow\",\"type\":\"hardware\",\"hostname\":\"srly-4shnfrdc5cd2p0p\",\"ws_open\":false,\"status\":\"Offline\",\"last_screenshot\":\"https://us-assets.screenlyapp.com/01CD1W50NR000A28F31W83B1TY/screenshots/01F98G8MJB6FC809MGGYTSWZNN/5267668e6db35498e61b83d4c702dbe8\",\"in_sync\":false,\"software_version\":\"Screenly 2 Player\",\"hardware_version\":\"Raspberry Pi 3B\",\"config\":{\"hdmi_mode\": 34, \"hdmi_boost\": 2, \"hdmi_drive\": 0, \"hdmi_group\": 0, \"verify_ssl\": true, \"audio_output\": \"hdmi\", \"hdmi_timings\": \"\", \"overscan_top\": 0, \"overscan_left\": 0, \"use_composite\": false, \"display_rotate\": 0, \"overscan_right\": 0, \"overscan_scale\": 0, \"overscan_bottom\": 0, \"disable_overscan\": 0, \"shuffle_playlist\": false, \"framebuffer_width\": 0, \"use_composite_pal\": false, \"framebuffer_height\": 0, \"hdmi_force_hotplug\": true, \"use_composite_ntsc\": false, \"hdmi_pixel_encoding\": 0, \"play_history_enabled\": false}}]").unwrap());
+
+        let expected_output = concat!(
+"+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n",
+"| Id                                   | Name                            | Hardware version | In sync | Last ping                     | Uptime (seconds) |\n",
+"+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n",
+"| 017a5104-524b-33d8-8026-9087b59e7eb5 | Renat's integrated wired NM     | Raspberry Pi 3B  | false   | 2021-08-25T06:17:20.728+00:00 | 230728.38        |\n",
+"+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n",
+"| 017a5104-524b-33d8-8026-9087b59e7eb6 | Not Renat's integrated wired NM | Raspberry Pi 3B  | false   | 2020-08-25T06:17:20.728+00:00 | 230728.38        |\n",
+"+--------------------------------------+---------------------------------+------------------+---------+-------------------------------+------------------+\n");
+
+        assert_eq!(screen.format(OutputType::HumanReadable), expected_output);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod authentication;
 mod commands;
-#[macro_use]
+
 extern crate prettytable;
 use crate::authentication::{Authentication, AuthenticationError};
 use clap::{command, Parser, Subcommand};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,26 @@
 mod authentication;
 mod commands;
-
+#[macro_use]
+extern crate prettytable;
 use crate::authentication::{Authentication, AuthenticationError};
 use clap::{command, Parser, Subcommand};
 
+use crate::commands::{Formatter, OutputType};
 use simple_logger::SimpleLogger;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "Command line interface is intended for quick interaction with Screenly through terminal. Moreover, this CLI is built such that it can be used for automating tasks."
+)]
 #[command(propagate_version = true)]
 struct Cli {
+    /// Enables json output
+    #[arg(short, long)]
+    json: Option<u8>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -26,9 +37,18 @@ enum Commands {
 #[derive(Subcommand, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum ScreenCommands {
     /// Lists your screens
-    List,
+    List {
+        /// Enables json output
+        #[arg(short, long, action = clap::ArgAction::SetTrue)]
+        json: Option<bool>,
+    },
     /// Gets a single screen by id
-    Get { id: String },
+    Get {
+        /// Enables json output
+        #[arg(short, long, action = clap::ArgAction::SetTrue)]
+        json: Option<bool>,
+        id: String,
+    },
 }
 
 fn main() {
@@ -57,14 +77,16 @@ fn main() {
             },
         },
         Commands::Screen(command) => match command {
-            ScreenCommands::List => {
+            ScreenCommands::List { json } => {
                 let screen_command = commands::ScreenCommand::new(authentication);
                 match screen_command.list() {
-                    Ok(v) => {
-                        println!(
-                            "{}",
-                            serde_json::to_string_pretty(&v).unwrap_or_else(|_| "{}".to_string())
-                        );
+                    Ok(screen) => {
+                        let output_type = if json.unwrap_or(false) {
+                            OutputType::Json
+                        } else {
+                            OutputType::HumanReadable
+                        };
+                        println!("{}", screen.format(output_type));
                     }
                     Err(e) => {
                         eprintln!("Error occurred: {:?}", e);
@@ -72,14 +94,17 @@ fn main() {
                     }
                 }
             }
-            ScreenCommands::Get { id } => {
+            ScreenCommands::Get { id, json } => {
                 let screen_command = commands::ScreenCommand::new(authentication);
                 match screen_command.get(id) {
-                    Ok(v) => {
-                        println!(
-                            "{}",
-                            serde_json::to_string_pretty(&v).unwrap_or_else(|_| "{}".to_string())
-                        );
+                    Ok(screen) => {
+                        let output_type = if json.unwrap_or(false) {
+                            OutputType::Json
+                        } else {
+                            OutputType::HumanReadable
+                        };
+
+                        println!("{}", screen.format(output_type));
                         std::process::exit(0);
                     }
                     Err(e) => {


### PR DESCRIPTION
By default, we will have a defined human-readable output. Using -j will set the output type to JSON and print the whole underlying object. Note that the final list of fields shown by default is still subject to change.

Example output:
![image](https://user-images.githubusercontent.com/916132/200513185-53dc3228-fd07-4ee0-81cc-864e7d1986c9.png)

## What does this PR do?
Adds new "-j" option for screen commands.
## GitHub issue or Phabricator ticket number?
https://ph.wireload.net/T6409
## How has this been tested?
Manually plus unit test
## Checklist before merging

- [x] If have added tests.
- [x] Is this a new feature? If yes, please write one phrase about this update.
- [x] I've attached relevant screenshots (if relevant).
