### PR TITLE
Update workflow release. Previous gh action used did not support apple arm 64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,28 +6,64 @@ on:
       - '*'
 
 jobs:
-  release:
-    name: release ${{ matrix.target }}
+  linux_x86:
+    name: Linux x86
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-pc-windows-gnu
-            archive: zip
-          - target: x86_64-unknown-linux-musl
-            archive: tar.gz tar.xz tar.zst
-          - target: x86_64-apple-darwin
-            archive: zip
-          - target: aarch64-apple-darwin
-            archive: zip
-
     steps:
-      - uses: actions/checkout@master
-      - name: Compile and release
-        uses: rust-build/rust-build.action@v1.4.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
-          RUSTTARGET: ${{ matrix.target }}
-          ARCHIVE_TYPES: ${{ matrix.archive }}
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: Zip artifact for deployment
+        run: zip screenly-cli-linux-x86.zip target/release/screenly
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Upload x86 binaries
+          path: screenly-cli-linux-x86.zip
+  macos_intel:
+    name: Macos Intel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-apple-darwin
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target x86_64-apple-darwin
+      - name: Zip artifact for deployment
+        run: zip screenly-cli-apple-x86.zip target/x86_64-apple-darwin/release/screenly
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Upload x86 binaries
+          path: screenly-cli-apple-x86.zip
+  macos_arm64:
+    name: Macos arm64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target aarch64-apple-darwin
+      - name: Zip artifact for deployment
+        run: zip screenly-cli-apple-arm64.zip target/release/screenly
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Upload arm64 apple binaries
+          path: screenly-cli-apple-arm64.zip
+


### PR DESCRIPTION
## What does this PR do?
..
## GitHub issue or Phabricator ticket number?
.
## How has this been tested?
no
## Checklist before merging

- [ ] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
