### PR TITLE
Attempts to fix build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-docker-image:
+    name: docker
+    needs: build-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Build container
-        run: docker build \
+        run: docker build . \
           --build-arg "RELEASE=$GITHUB_REF_NAME" \
-          -t "screenly/cli:$GITHUB_REF_NAME" .
+          -t "screenly/cli:$GITHUB_REF_NAME"
 
       - name: Tag container
         run: docker tag \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM alpine:3 as builder
 WORKDIR /usr/src/screenly-cli
 RUN apk add --no-cache wget tar
 ARG RELEASE=v0.1.0
-RUN wget "https://github.com/Screenly/cli/releases/download/$RELEASE/screenly-cli-x86_64-unknown-linux-gnu.tar.gz"
-RUN tar xfz screenly-cli-x86_64-unknown-linux-gnu.tar.gz
+RUN wget "https://github.com/Screenly/cli/releases/download/$RELEASE/screenly-cli-x86_64-unknown-linux-musl.tar.gz"
+RUN tar xfz screenly-cli-x86_64-unknown-linux-musl.tar.gz
 
 FROM alpine:3
 COPY --from=builder /usr/src/screenly-cli/screenly /usr/bin/


### PR DESCRIPTION
* Breaks out the docker build as a separate job in the GitHub Actions Workflow rather than a step.
* Moves to use the `musl` build.