### PR TITLE
New asset commands

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 openssl = { version = '0.10', features = ["vendored"] }
 anyhow = "1.0.65"
-clap = { version = "4.0.17", features = ["derive"] }
+clap = { version = "4.0.17", features = ["derive", "cargo"] }
 envtestkit = "1.1.2"
 humantime = "2.1.0"
 indicatif = "0.17.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tempdir = "0.3.7"
 term = "0.7.0"
 thiserror = "1.0.37"
 dirs = "4.0.0"
+http-auth-basic = "0.3.3"
 
 [dev-dependencies]
 httpmock = "0.6"

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -130,8 +130,7 @@ mod tests {
     use simple_logger::SimpleLogger;
     use tempdir::TempDir;
 
-    use crate::authentication::Config;
-    use crate::Authentication;
+    use super::*;
 
     #[test]
     fn test_verify_and_store_token_when_token_is_valid() {

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -13,19 +13,19 @@ pub struct Config {
 #[derive(Error, Debug)]
 pub enum AuthenticationError {
     #[error("wrong credentials error")]
-    WrongCredentialsError,
+    WrongCredentials,
     #[error("no credentials error")]
-    NoCredentialsError,
+    NoCredentials,
     #[error("request error")]
-    RequestError(#[from] reqwest::Error),
+    Request(#[from] reqwest::Error),
     #[error("i/o error")]
-    IoError(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
     #[error("env error")]
-    EnvError(#[from] env::VarError),
+    Env(#[from] env::VarError),
     #[error("missing home dir error")]
-    MissingHomeDirError(),
+    MissingHomeDir(),
     #[error("invalid header error")]
-    InvalidHeaderError(#[from] InvalidHeaderValue),
+    InvalidHeader(#[from] InvalidHeaderValue),
     #[error("unknown error")]
     Unknown,
 }
@@ -61,9 +61,9 @@ impl Authentication {
 
         match dirs::home_dir() {
             Some(path) => {
-                fs::read_to_string(path.join(".screenly")).map_err(AuthenticationError::IoError)
+                fs::read_to_string(path.join(".screenly")).map_err(AuthenticationError::Io)
             }
-            None => Err(AuthenticationError::NoCredentialsError),
+            None => Err(AuthenticationError::NoCredentials),
         }
     }
 
@@ -80,7 +80,7 @@ impl Authentication {
                 fs::write(home.join(".screenly"), token)?;
                 Ok(())
             }
-            None => Err(AuthenticationError::MissingHomeDirError()),
+            None => Err(AuthenticationError::MissingHomeDir()),
         }
     }
 
@@ -96,7 +96,7 @@ impl Authentication {
             .send()?;
 
         match res.status().as_u16() {
-            401 => Err(AuthenticationError::WrongCredentialsError),
+            401 => Err(AuthenticationError::WrongCredentials),
             404 => Ok(()),
             _ => Err(AuthenticationError::Unknown),
         }
@@ -115,7 +115,7 @@ impl Authentication {
         reqwest::blocking::Client::builder()
             .default_headers(default_headers)
             .build()
-            .map_err(AuthenticationError::RequestError)
+            .map_err(AuthenticationError::Request)
     }
 }
 
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_token_when_token_is_overriden_with_env_variable_correct_token_is_returned() {
+    fn test_read_token_when_token_is_overridden_with_env_variable_correct_token_is_returned() {
         let tmp_dir = TempDir::new("test").unwrap();
         let _lock = lock_test();
         let _token = set_env(OsString::from("API_TOKEN"), "env_token");

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -344,7 +344,7 @@ impl AssetCommand {
         Ok(Assets::new(serde_json::from_str(&response.text()?)?))
     }
 
-    pub fn set_headers(
+    pub fn set_web_asset_headers(
         &self,
         id: &str,
         headers: Vec<(String, String)>,
@@ -810,7 +810,9 @@ mod tests {
         let authentication = Authentication::new_with_config(config);
         let asset_command = AssetCommand::new(authentication);
         let headers = vec![("k".to_owned(), "v".to_owned())];
-        assert!(asset_command.set_headers("test-id", headers).is_ok());
+        assert!(asset_command
+            .set_web_asset_headers("test-id", headers)
+            .is_ok());
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -347,14 +347,11 @@ impl AssetCommand {
     pub fn set_headers(
         &self,
         id: &str,
-        headers: HashMap<&str, &str>,
+        headers: Vec<(String, String)>,
     ) -> anyhow::Result<(), CommandError> {
         let endpoint = format!("v4/assets?id=eq.{}", id);
-        patch(
-            &self.authentication,
-            &endpoint,
-            &json!({ "headers": headers }),
-        )
+        let map: HashMap<_, _> = headers.into_iter().collect();
+        patch(&self.authentication, &endpoint, &json!({ "headers": map }))
     }
 
     pub fn inject_js(&self, id: &str, js_code: &str) -> anyhow::Result<(), CommandError> {
@@ -812,9 +809,7 @@ mod tests {
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config);
         let asset_command = AssetCommand::new(authentication);
-        let mut headers = HashMap::new();
-        headers.insert("k", "v");
-
+        let headers = vec![("k".to_owned(), "v".to_owned())];
         assert!(asset_command.set_headers("test-id", headers).is_ok());
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -308,7 +308,7 @@ impl AssetCommand {
 
         if path.starts_with("http://") || path.starts_with("https://") {
             let mut payload = HashMap::new();
-            payload.insert("title", title.clone());
+            payload.insert("title", title);
             payload.insert("source_url", path);
             return self.add_web_asset(&url, &headers, &payload);
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -23,17 +23,17 @@ pub trait Formatter {
 #[derive(Error, Debug)]
 pub enum CommandError {
     #[error("auth error")]
-    AuthenticationError(#[from] AuthenticationError),
+    Authentication(#[from] AuthenticationError),
     #[error("request error")]
-    RequestError(#[from] reqwest::Error),
+    Request(#[from] reqwest::Error),
     #[error("parse error")]
-    ParseError(#[from] serde_json::Error),
+    Parse(#[from] serde_json::Error),
     #[error("unknown error #[0]")]
     WrongResponseStatus(u16),
     #[error("Required field is missing in the response")]
     MissingField,
     #[error("I/O error #[0]")]
-    IoError(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
     #[error("Invalid header value")]
     InvalidHeaderValue(#[from] InvalidHeaderValue),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ enum AssetCommands {
     },
 }
 
-fn handle_command_execution_result<T: commands::Formatter>(
+fn handle_command_execution_result<T: Formatter>(
     result: anyhow::Result<T, CommandError>,
     json: &Option<bool>,
 ) {
@@ -123,7 +123,7 @@ fn handle_command_execution_result<T: commands::Formatter>(
         }
         Err(e) => {
             match e {
-                CommandError::AuthenticationError(_) => {
+                CommandError::Authentication(_) => {
                     error!(
                         "Authentication error occurred. Please use login command to authenticate."
                     )
@@ -196,7 +196,7 @@ fn main() {
             }
 
             Err(e) => match e {
-                AuthenticationError::WrongCredentialsError => {
+                AuthenticationError::WrongCredentials => {
                     error!("Token verification failed.");
                     std::process::exit(1);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,7 +347,7 @@ fn main() {
                         }
                     }
                 } else {
-                    match fs::read_to_string(&path) {
+                    match fs::read_to_string(path) {
                         Ok(text) => text,
                         Err(e) => {
                             error!("Failed to read file with JS injection code. Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,7 +389,7 @@ fn main() {
             }
             AssetCommands::SetHeaders { uuid, headers } => {
                 let asset_command = commands::AssetCommand::new(authentication);
-                match asset_command.set_headers(uuid, headers.clone()) {
+                match asset_command.set_web_asset_headers(uuid, headers.clone()) {
                     Ok(()) => {
                         info!("Asset updated successfully.");
                     }
@@ -402,7 +402,7 @@ fn main() {
             AssetCommands::BasicAuth { uuid, credentials } => {
                 let asset_command = commands::AssetCommand::new(authentication);
                 let basic_auth = Credentials::new(&credentials.0, &credentials.1);
-                match asset_command.set_headers(
+                match asset_command.set_web_asset_headers(
                     uuid,
                     vec![("Authorization".to_owned(), basic_auth.as_http_header())],
                 ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,7 @@ enum ParseError {
     MissingSymbol(),
 }
 fn parse_key_val(s: &str) -> Result<(String, String), ParseError> {
-    let pos = s
-        .find('=')
-        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{}`", s))
-        .map_err(|_| ParseError::MissingSymbol())?;
+    let pos = s.find('=').ok_or(ParseError::MissingSymbol())?;
     Ok((s[..pos].to_string(), s[pos + 1..].to_string()))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,10 +271,7 @@ fn main() {
             }
             AssetCommands::Add { path, title, json } => {
                 let asset_command = commands::AssetCommand::new(authentication);
-                handle_command_execution_result(
-                    asset_command.add(path.clone(), title.clone()),
-                    json,
-                );
+                handle_command_execution_result(asset_command.add(path, title), json);
             }
             AssetCommands::Delete { uuid } => {
                 let asset_command = commands::AssetCommand::new(authentication);


### PR DESCRIPTION
## What does this PR do?
Supports `inject-js` and `set-headers` commands for web assets. 
Inject-js allows setting JS injection code for web assets. Injected code will be executed during playback on the device once the asset is loaded.

set-headers similarly works on web assets setting values of custom HTTP headers.
Usage is a bit awkward but I did not come up with better syntax:
```screenly asset set-headers 01FJVFP0QVD1E5TA70SA66AJPF --header k=v --header k2=v2```

Also adds `basic-auth` command that allows setting the basic auth header by accepting username and password.

## GitHub issue or Phabricator ticket number?
T6482
## How has this been tested?
New unit tests + manual use.

## Checklist before merging

- [x] If have added tests.
- [x] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
