### PR TITLE
Ask for API token interactively to avoid having password in terminal …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ term = "0.7.0"
 thiserror = "1.0.37"
 dirs = "4.0.0"
 http-auth-basic = "0.3.3"
+rpassword = "7.2.0"
 
 [dev-dependencies]
 httpmock = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use clap::{command, Parser, Subcommand};
 
 use http_auth_basic::Credentials;
 use log::{error, info};
+use rpassword::read_password;
 use simple_logger::SimpleLogger;
 use std::io::Write;
 use std::{fs, io};
@@ -43,7 +44,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Logins with the token and stores it for further use if it's valid. You can set API_TOKEN environment variable to override used API token.
-    Login { token: String },
+    Login {},
     /// Screen related commands.
     #[command(subcommand)]
     Screen(ScreenCommands),
@@ -229,23 +230,28 @@ fn main() {
 
     let authentication = Authentication::new();
     match &cli.command {
-        Commands::Login { token } => match authentication.verify_and_store_token(token) {
-            Ok(()) => {
-                info!("Login credentials have been saved.");
-                std::process::exit(0);
-            }
+        Commands::Login {} => {
+            print!("Enter your API Token: ");
+            std::io::stdout().flush().unwrap();
+            let token = read_password().unwrap();
+            match authentication.verify_and_store_token(&token) {
+                Ok(()) => {
+                    info!("Login credentials have been saved.");
+                    std::process::exit(0);
+                }
 
-            Err(e) => match e {
-                AuthenticationError::WrongCredentials => {
-                    error!("Token verification failed.");
-                    std::process::exit(1);
-                }
-                _ => {
-                    error!("Error occurred: {:?}", e);
-                    std::process::exit(1);
-                }
-            },
-        },
+                Err(e) => match e {
+                    AuthenticationError::WrongCredentials => {
+                        error!("Token verification failed.");
+                        std::process::exit(1);
+                    }
+                    _ => {
+                        error!("Error occurred: {:?}", e);
+                        std::process::exit(1);
+                    }
+                },
+            }
+        }
         Commands::Screen(command) => match command {
             ScreenCommands::List { json } => {
                 let screen_command = commands::ScreenCommand::new(authentication);


### PR DESCRIPTION
…history.

## What does this PR do?
Users are now asked to input API token in the interactive dialogue. The API token is not saved to the terminal history or displayed in the terminal.
## GitHub issue or Phabricator ticket number?
https://github.com/Screenly/cli/issues/12
## How has this been tested?
Manually
## Checklist before merging

- [ ] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
