### PR TITLE
Bearer authentication command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,7 +181,7 @@ pub enum AssetCommands {
     },
     /// Shortcut for setting up bearer authentication headers.
     BearerAuth {
-        /// UUID of the web asset to set up basic authentication for.
+        /// UUID of the web asset to set up bearer authentication for.
         uuid: String,
         /// Bearer token.
         token: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use crate::commands::{CommandError, Formatter, OutputType};
 use clap::{Parser, Subcommand};
 use http_auth_basic::Credentials;
 use log::{error, info};
+use reqwest::StatusCode;
 use rpassword::read_password;
 use std::io::Write;
 use std::path::PathBuf;
@@ -459,8 +460,8 @@ pub fn handle_cli_asset_command(command: &AssetCommands) {
             let js_code = if path.starts_with("http://") || path.starts_with("https://") {
                 match reqwest::blocking::get(path) {
                     Ok(response) => {
-                        match response.status().as_u16() {
-                            200 => response.text().unwrap_or_default(),
+                        match response.status() {
+                            StatusCode::OK => response.text().unwrap_or_default(),
                             status => {
                                 error!("Failed to retrieve JS injection code. Wrong response status: {}", status);
                                 std::process::exit(1);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,6 +178,13 @@ pub enum AssetCommands {
         #[arg(value_parser = parse_key_val)]
         credentials: (String, String),
     },
+    /// Shortcut for setting up bearer authentication headers.
+    BearerAuth {
+        /// UUID of the web asset to set up basic authentication for.
+        uuid: String,
+        /// Bearer token.
+        token: String,
+    },
 }
 
 #[derive(Subcommand, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -516,6 +523,21 @@ pub fn handle_cli_asset_command(command: &AssetCommands) {
         AssetCommands::UpdateHeaders { uuid, headers } => {
             let asset_command = commands::asset::AssetCommand::new(authentication);
             match asset_command.update_web_asset_headers(uuid, headers.headers.clone()) {
+                Ok(()) => {
+                    info!("Asset updated successfully.");
+                }
+                Err(e) => {
+                    error!("Error occurred: {:?}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        AssetCommands::BearerAuth { uuid, token } => {
+            let asset_command = commands::asset::AssetCommand::new(authentication);
+            match asset_command.update_web_asset_headers(
+                uuid,
+                vec![("Authorization".to_owned(), format!("Bearer {token}"))],
+            ) {
                 Ok(()) => {
                     info!("Asset updated successfully.");
                 }


### PR DESCRIPTION
## What does this PR do?
Adds shortcut for setting bearer authentication in a similar way we have a command for basic auth.
For usage:
```screenly asset bearer-auth <uuid> <token>```
## GitHub issue or Phabricator ticket number?
-
## How has this been tested?
manually.
## Checklist before merging

- [ ] If have added tests.
- [x] Is this a new feature? If yes, please write one phrase about this update.
Described in the PR description
- [ ] I've attached relevant screenshots (if relevant).
