### PR TITLE
Enable sentry for cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ tempdir = "0.3.7"
 term = "0.7.0"
 thiserror = "1.0.37"
 walkdir = "2.3.3"
+sentry = "0.31.5"
+sentry-anyhow = "0.31.5"
 
 [dev-dependencies]
 httpmock = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ extern crate prettytable;
 use crate::authentication::{Authentication, AuthenticationError};
 use clap::Parser;
 use simple_logger::SimpleLogger;
-use sentry_anyhow::capture_anyhow;
 
 fn main() {
     SimpleLogger::new().init().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,17 @@ extern crate prettytable;
 use crate::authentication::{Authentication, AuthenticationError};
 use clap::Parser;
 use simple_logger::SimpleLogger;
+use sentry_anyhow::capture_anyhow;
 
 fn main() {
     SimpleLogger::new().init().unwrap();
+
+    let _sentry_dns = "https://cf4fbc3a05024138ad8ef56f218fbb0e@o1402263.ingest.sentry.io/4505391836233728";
+
+    let _guard = sentry::init((_sentry_dns, sentry::ClientOptions {
+        release: sentry::release_name!(),
+        ..Default::default()
+    }));
 
     let cli = cli::Cli::parse();
     cli::handle_cli(&cli);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,9 @@ use simple_logger::SimpleLogger;
 fn main() {
     SimpleLogger::new().init().unwrap();
 
-    let _sentry_dns = "https://cf4fbc3a05024138ad8ef56f218fbb0e@o1402263.ingest.sentry.io/4505391836233728";
+    let _sentry_dsn = "https://891eb4b6f8ff4f959fd76a587d9ab302@o4505481987489792.ingest.sentry.io/4505482139140096";
 
-    let _guard = sentry::init((_sentry_dns, sentry::ClientOptions {
+    let _guard = sentry::init((_sentry_dsn, sentry::ClientOptions {
         release: sentry::release_name!(),
         ..Default::default()
     }));


### PR DESCRIPTION
## What does this PR do?
Enables Sentry for CLI

## GitHub issue or Phabricator ticket number?
https://ph.wireload.net/T7072

## How has this been tested?
I called `capture_anyhow` and `panic!` in code, it was reported by Sentry:
![image](https://github.com/Screenly/cli/assets/135842671/184830d9-c382-4cea-9ed1-f864851e1a79)

