### PR TITLE
Store the token when possible - allows to remove locks on all tests

### DIFF
--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -33,6 +33,7 @@ pub enum AuthenticationError {
 
 pub struct Authentication {
     pub config: Config,
+    pub token: String,
 }
 
 impl Config {
@@ -49,13 +50,14 @@ impl Config {
 }
 
 impl Authentication {
-    pub fn new() -> Self {
-        Self {
+    pub fn new() -> Result<Self, AuthenticationError> {
+        Ok(Self {
             config: Config::default(),
-        }
+            token: Self::read_token()?,
+        })
     }
 
-    pub fn read_token() -> Result<String, AuthenticationError> {
+    fn read_token() -> Result<String, AuthenticationError> {
         if let Ok(token) = env::var("API_TOKEN") {
             return Ok(token);
         }
@@ -68,9 +70,11 @@ impl Authentication {
         }
     }
 
-    #[cfg(test)]
-    pub fn new_with_config(config: Config) -> Self {
-        Self { config }
+    pub fn new_with_config(config: Config, token: &str) -> Self {
+        Self {
+            config,
+            token: token.to_string(),
+        }
     }
 
     pub fn verify_and_store_token(&self, token: &str) -> anyhow::Result<(), AuthenticationError> {
@@ -104,7 +108,7 @@ impl Authentication {
     }
 
     pub fn build_client(&self) -> Result<reqwest::blocking::Client, AuthenticationError> {
-        let token = Authentication::read_token()?;
+        let token = self.token.clone();
         let secret = format!("Token {token}");
         let mut default_headers = HeaderMap::new();
         default_headers.insert(header::AUTHORIZATION, secret.parse()?);
@@ -142,6 +146,7 @@ mod tests {
         let tmp_dir = TempDir::new("test").unwrap();
         let _lock = lock_test();
         let _test = set_env(OsString::from("HOME"), tmp_dir.path().to_str().unwrap());
+
         let mock_server = MockServer::start();
         mock_server.mock(|when, then| {
             when.method(GET)
@@ -151,7 +156,8 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "");
+
         assert!(authentication
             .verify_and_store_token("correct_token")
             .is_ok());
@@ -165,8 +171,6 @@ mod tests {
     #[test]
     fn test_verify_and_store_token_when_token_is_invalid() {
         let tmp_dir = TempDir::new("invalid").unwrap();
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("HOME"), tmp_dir.path().to_str().unwrap());
         let mock_server = MockServer::start();
         mock_server.mock(|when, then| {
             when.method(GET)
@@ -175,7 +179,8 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let mut authentication = Authentication::new().unwrap();
+        authentication.config = config;
         assert!(authentication
             .verify_and_store_token("wrong_token")
             .is_err());

--- a/src/commands/asset.rs
+++ b/src/commands/asset.rs
@@ -158,18 +158,15 @@ mod tests {
     use super::*;
     use crate::authentication::Config;
     use crate::commands::{Formatter, OutputType};
-    use envtestkit::lock::lock_test;
-    use envtestkit::set_env;
+
     use httpmock::Method::{DELETE, GET, PATCH, POST};
     use httpmock::MockServer;
-    use std::ffi::OsString;
+
     use std::fs;
     use tempdir::TempDir;
 
     #[test]
     fn test_list_assets_should_return_correct_asset_list() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let asset_list = json!([{
           "asset_group_id": null,
           "asset_url": "https://us-assets.screenlyapp.com/test13",
@@ -222,7 +219,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let asset_command = AssetCommand::new(authentication);
         let v = asset_command.list().unwrap();
         assert_eq!(v.value, asset_list);
@@ -231,8 +228,6 @@ mod tests {
     #[test]
     fn test_add_asset_when_local_asset_should_send_correct_request() {
         let tmp_dir = TempDir::new("test").unwrap();
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         fs::write(tmp_dir.path().join("1.html").to_str().unwrap(), "dummy").unwrap();
 
         let new_asset = json!([
@@ -272,7 +267,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let asset_command = AssetCommand::new(authentication);
         let v = asset_command.add(tmp_dir.path().join("1.html").to_str().unwrap(), "test");
         post_mock.assert();
@@ -284,9 +279,6 @@ mod tests {
     #[test]
     fn test_add_asset_when_web_asset_should_send_correct_request() {
         let tmp_dir = TempDir::new("test").unwrap();
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("HOME"), tmp_dir.path().to_str().unwrap());
-        fs::write(tmp_dir.path().join(".screenly").to_str().unwrap(), "token").unwrap();
         fs::write(tmp_dir.path().join("1.html").to_str().unwrap(), "dummy").unwrap();
 
         let new_asset = json!([
@@ -325,7 +317,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let asset_command = AssetCommand::new(authentication);
         let v = asset_command.add("https://google.com", "test");
         assert!(v.is_ok());
@@ -335,9 +327,6 @@ mod tests {
 
     #[test]
     fn test_get_asset_should_return_asset() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let asset = json!(  [{
           "asset_group_id": "017b0187-d887-3c79-7b67-18c94098345d",
           "asset_url": "https://vimeo.com/1084537",
@@ -372,7 +361,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let asset_command = AssetCommand::new(authentication);
 
         let v = asset_command.get("017b0187-d887-3c79-7b67-18c94098345d");
@@ -383,8 +372,6 @@ mod tests {
 
     #[test]
     fn test_delete_asset_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         let delete_mock = mock_server.mock(|when, then| {
             when.method(DELETE)
@@ -399,7 +386,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let asset_command = AssetCommand::new(authentication);
         let result = asset_command.delete("test-id");
         delete_mock.assert();
@@ -444,8 +431,6 @@ mod tests {
 
     #[test]
     fn test_inject_js_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         let patch_mock = mock_server.mock(|when, then| {
             when.method(PATCH)
@@ -461,7 +446,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let asset_command = AssetCommand::new(authentication);
         let result = asset_command.inject_js("test-id", "console.log(1)");
         patch_mock.assert();
@@ -470,8 +455,6 @@ mod tests {
 
     #[test]
     fn test_set_headers_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         let patch_mock = mock_server.mock(|when, then| {
             when.method(PATCH)
@@ -487,7 +470,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let asset_command = AssetCommand::new(authentication);
         let headers = vec![("k".to_owned(), "v".to_owned())];
         let result = asset_command.set_web_asset_headers("test-id", headers);
@@ -497,8 +480,6 @@ mod tests {
 
     #[test]
     fn test_update_headers_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         let asset = json!(  [{
           "asset_group_id": "017b0187-d887-3c79-7b67-18c94098345d",
@@ -546,7 +527,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let asset_command = AssetCommand::new(authentication);
         let headers = vec![("k".to_owned(), "v".to_owned())];
         let result = asset_command.update_web_asset_headers("test-id", headers);

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -481,18 +481,14 @@ impl EdgeAppCommand {
 mod tests {
     use super::*;
     use crate::authentication::Config;
-    use envtestkit::lock::lock_test;
-    use envtestkit::set_env;
+
     use httpmock::Method::{GET, PATCH, POST};
     use httpmock::MockServer;
-    use std::ffi::OsString;
+
     use tempdir::TempDir;
 
     #[test]
     fn test_edge_app_create_should_create_app_and_required_files() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let tmp_dir = TempDir::new("test").unwrap();
 
         let mock_server = MockServer::start();
@@ -508,7 +504,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
 
         let result = command.create(
@@ -533,8 +529,6 @@ mod tests {
 
     #[test]
     fn test_list_edge_apps_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         let edge_apps_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -548,7 +542,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let result = command.list();
         edge_apps_mock.assert();
@@ -557,8 +551,6 @@ mod tests {
 
     #[test]
     fn test_list_versions_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         let edge_apps_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -572,7 +564,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
             app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
@@ -596,8 +588,6 @@ mod tests {
 
     #[test]
     fn test_list_settings_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         let edge_apps_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -613,7 +603,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
             app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
@@ -634,9 +624,6 @@ mod tests {
 
     #[test]
     fn test_upload_should_send_correct_requests() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let manifest = EdgeAppManifest {
             app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
             root_asset_id: "".to_string(),
@@ -770,7 +757,7 @@ mod tests {
         EdgeAppManifest::save_to_file(&manifest, temp_dir.path().join("screenly.yml").as_path())
             .unwrap();
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let result = command.upload(temp_dir.path().join("screenly.yml").as_path());
 

--- a/src/commands/playlist.rs
+++ b/src/commands/playlist.rs
@@ -208,7 +208,7 @@ impl PlaylistCommand {
 mod tests {
     use super::*;
     use crate::authentication::Config;
-    use envtestkit::lock::lock_test;
+
     use envtestkit::set_env;
     use httpmock::Method::{DELETE, GET, PATCH, POST};
     use httpmock::MockServer;
@@ -216,9 +216,6 @@ mod tests {
 
     #[test]
     fn test_create_playlist_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let new_playlist_request = json!({
             "title": "Best playlist",
             "predicate": "FALSE",
@@ -246,7 +243,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = PlaylistCommand::new(authentication);
         let result = command.create("Best playlist", "FALSE");
         post_mock.assert();
@@ -255,7 +252,6 @@ mod tests {
 
     #[test]
     fn test_list_playlists_should_send_correct_request() {
-        let _lock = lock_test();
         let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         let playlists_mock = mock_server.mock(|when, then| {
@@ -270,7 +266,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = PlaylistCommand::new(authentication);
         let result = command.list();
         playlists_mock.assert();
@@ -279,9 +275,6 @@ mod tests {
 
     #[test]
     fn test_get_playlist_file_should_send_correct_request_and_return_playlist_file() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let playlist_items_response = json!([
           {
             "asset_id": "01AWJ47DP0000FXX7R00C5KX3F",
@@ -311,7 +304,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = PlaylistCommand::new(authentication);
         let result = command.get_playlist_file("testuuid");
 
@@ -341,9 +334,6 @@ mod tests {
 
     #[test]
     fn test_update_playlist_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let updated_playlist = json!({
           "predicate": "FALSE",
           "playlist_id": "test-playlist-id",
@@ -412,7 +402,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = PlaylistCommand::new(authentication);
         let result =
             command.update(&serde_json::from_value::<PlaylistFile>(updated_playlist).unwrap());
@@ -426,9 +416,6 @@ mod tests {
 
     #[test]
     fn test_delete_playlist_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let mock_server = MockServer::start();
         let delete_mock = mock_server.mock(|when, then| {
             when.method(DELETE)
@@ -443,7 +430,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = PlaylistCommand::new(authentication);
         let result = command.delete("test-id");
         delete_mock.assert();
@@ -452,9 +439,6 @@ mod tests {
 
     #[test]
     fn test_append_asset_to_playlist_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let items_request = json!([
           {
             "position": 300000,
@@ -488,7 +472,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = PlaylistCommand::new(authentication);
         let result = command.append_asset("test-playlist-id", "test-asset-id", 100);
 
@@ -499,9 +483,6 @@ mod tests {
 
     #[test]
     fn test_prepend_asset_to_playlist_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
-
         let _updated_playlist = json!({
           "predicate": "TRUE",
           "playlist_id": "test-playlist-id",
@@ -583,7 +564,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let command = PlaylistCommand::new(authentication);
         let result = command.prepend_asset("test-playlist-id", "test-asset-id", 100);
 

--- a/src/commands/screen.rs
+++ b/src/commands/screen.rs
@@ -71,11 +71,7 @@ mod tests {
 
     use httpmock::{Method::GET, MockServer};
 
-    use envtestkit::lock::lock_test;
-    use envtestkit::set_env;
     use httpmock::Method::{DELETE, POST};
-    use std::ffi::OsString;
-    use std::fs;
 
     use crate::authentication::{Authentication, Config};
     use crate::commands::{Formatter, OutputType};
@@ -84,10 +80,7 @@ mod tests {
 
     #[test]
     fn test_list_screens_should_return_correct_screen_list() {
-        let tmp_dir = TempDir::new("test").unwrap();
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("HOME"), tmp_dir.path().to_str().unwrap());
-        fs::write(tmp_dir.path().join(".screenly").to_str().unwrap(), "token").unwrap();
+        let _tmp_dir = TempDir::new("test").unwrap();
 
         let screens = serde_json::from_str::<Value>("[{\"id\":\"017a5104-524b-33d8-8026-9087b59e7eb5\",\"team_id\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"created_at\":\"2021-06-28T05:07:55+00:00\",\"name\":\"Renat's integrated wired NM\",\"is_enabled\":true,\"coords\":[55.22931, 48.90429],\"last_ping\":\"2021-08-25T06:17:20.728+00:00\",\"last_ip\":null,\"local_ip\":\"192.168.1.146\",\"mac\":\"b8:27:eb:d6:83:6f\",\"last_screenshot_time\":\"2021-08-25T06:09:04.399+00:00\",\"uptime\":\"230728.38\",\"load_avg\":\"0.14\",\"signal_strength\":null,\"interface\":\"eth0\",\"debug\":false,\"location\":\"Kamsko-Ust'inskiy rayon, Russia\",\"team\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"timezone\":\"Europe/Moscow\",\"type\":\"hardware\",\"hostname\":\"srly-4shnfrdc5cd2p0p\",\"ws_open\":false,\"status\":\"Offline\",\"last_screenshot\":\"https://us-assets.screenlyapp.com/01CD1W50NR000A28F31W83B1TY/screenshots/01F98G8MJB6FC809MGGYTSWZNN/5267668e6db35498e61b83d4c702dbe8\",\"in_sync\":false,\"software_version\":\"Screenly 2 Player\",\"hardware_version\":\"Raspberry Pi 3B\",\"config\":{\"hdmi_mode\": 34, \"hdmi_boost\": 2, \"hdmi_drive\": 0, \"hdmi_group\": 0, \"verify_ssl\": true, \"audio_output\": \"hdmi\", \"hdmi_timings\": \"\", \"overscan_top\": 0, \"overscan_left\": 0, \"use_composite\": false, \"display_rotate\": 0, \"overscan_right\": 0, \"overscan_scale\": 0, \"overscan_bottom\": 0, \"disable_overscan\": 0, \"shuffle_playlist\": false, \"framebuffer_width\": 0, \"use_composite_pal\": false, \"framebuffer_height\": 0, \"hdmi_force_hotplug\": true, \"use_composite_ntsc\": false, \"hdmi_pixel_encoding\": 0, \"play_history_enabled\": false}}]").unwrap();
 
@@ -104,7 +97,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let screen_command = ScreenCommand::new(authentication);
         let v = screen_command.list().unwrap();
         assert_eq!(v.value, screens);
@@ -112,10 +105,7 @@ mod tests {
 
     #[test]
     fn test_add_screen_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let new_screen = serde_json::from_str::<Value>("{\"id\":\"017a5104-524b-33d8-8026-9087b59e7eb5\",\"team_id\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"created_at\":\"2021-06-28T05:07:55+00:00\",\"name\":\"Test\",\"is_enabled\":true,\"coords\":[55.22931, 48.90429],\"last_ping\":\"2021-08-25T06:17:20.728+00:00\",\"last_ip\":null,\"local_ip\":\"192.168.1.146\",\"mac\":\"b8:27:eb:d6:83:6f\",\"last_screenshot_time\":\"2021-08-25T06:09:04.399+00:00\",\"uptime\":\"230728.38\",\"load_avg\":\"0.14\",\"signal_strength\":null,\"interface\":\"eth0\",\"debug\":false,\"location\":\"Kamsko-Ust'inskiy rayon, Russia\",\"team\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"timezone\":\"Europe/Moscow\",\"type\":\"hardware\",\"hostname\":\"srly-4shnfrdc5cd2p0p\",\"ws_open\":false,\"status\":\"Offline\",\"last_screenshot\":\"https://us-assets.screenlyapp.com/01CD1W50NR000A28F31W83B1TY/screenshots/01F98G8MJB6FC809MGGYTSWZNN/5267668e6db35498e61b83d4c702dbe8\",\"in_sync\":false,\"software_version\":\"Screenly 2 Player\",\"hardware_version\":\"Raspberry Pi 3B\",\"config\":{\"hdmi_mode\": 34, \"hdmi_boost\": 2, \"hdmi_drive\": 0, \"hdmi_group\": 0, \"verify_ssl\": true, \"audio_output\": \"hdmi\", \"hdmi_timings\": \"\", \"overscan_top\": 0, \"overscan_left\": 0, \"use_composite\": false, \"display_rotate\": 0, \"overscan_right\": 0, \"overscan_scale\": 0, \"overscan_bottom\": 0, \"disable_overscan\": 0, \"shuffle_playlist\": false, \"framebuffer_width\": 0, \"use_composite_pal\": false, \"framebuffer_height\": 0, \"hdmi_force_hotplug\": true, \"use_composite_ntsc\": false, \"hdmi_pixel_encoding\": 0, \"play_history_enabled\": false}}").unwrap();
-
         let mock_server = MockServer::start();
         let post_mock = mock_server.mock(|when, then| {
             when.method(POST)
@@ -131,7 +121,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let screen_command = ScreenCommand::new(authentication);
         let v = screen_command.add("test-pin", Some("test".to_string()));
         post_mock.assert();
@@ -141,8 +131,6 @@ mod tests {
 
     #[test]
     fn test_get_screen_should_return_screen() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         mock_server.mock(|when, then| {
             when.method(GET)
@@ -156,7 +144,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let screen_command = ScreenCommand::new(authentication);
         let expected = serde_json::from_str::<Value>("[{\"id\":\"017a5104-524b-33d8-8026-9087b59e7eb5\",\"team_id\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"created_at\":\"2021-06-28T05:07:55+00:00\",\"name\":\"Renat's integrated wired NM\",\"is_enabled\":true,\"coords\":[55.22931, 48.90429],\"last_ping\":\"2021-08-25T06:17:20.728+00:00\",\"last_ip\":null,\"local_ip\":\"192.168.1.146\",\"mac\":\"b8:27:eb:d6:83:6f\",\"last_screenshot_time\":\"2021-08-25T06:09:04.399+00:00\",\"uptime\":\"230728.38\",\"load_avg\":\"0.14\",\"signal_strength\":null,\"interface\":\"eth0\",\"debug\":false,\"location\":\"Kamsko-Ust'inskiy rayon, Russia\",\"team\":\"016343c2-82b8-0000-a121-e30f1035875e\",\"timezone\":\"Europe/Moscow\",\"type\":\"hardware\",\"hostname\":\"srly-4shnfrdc5cd2p0p\",\"ws_open\":false,\"status\":\"Offline\",\"last_screenshot\":\"https://us-assets.screenlyapp.com/01CD1W50NR000A28F31W83B1TY/screenshots/01F98G8MJB6FC809MGGYTSWZNN/5267668e6db35498e61b83d4c702dbe8\",\"in_sync\":false,\"software_version\":\"Screenly 2 Player\",\"hardware_version\":\"Raspberry Pi 3B\",\"config\":{\"hdmi_mode\": 34, \"hdmi_boost\": 2, \"hdmi_drive\": 0, \"hdmi_group\": 0, \"verify_ssl\": true, \"audio_output\": \"hdmi\", \"hdmi_timings\": \"\", \"overscan_top\": 0, \"overscan_left\": 0, \"use_composite\": false, \"display_rotate\": 0, \"overscan_right\": 0, \"overscan_scale\": 0, \"overscan_bottom\": 0, \"disable_overscan\": 0, \"shuffle_playlist\": false, \"framebuffer_width\": 0, \"use_composite_pal\": false, \"framebuffer_height\": 0, \"hdmi_force_hotplug\": true, \"use_composite_ntsc\": false, \"hdmi_pixel_encoding\": 0, \"play_history_enabled\": false}}]").unwrap();
         let v = screen_command
@@ -167,8 +155,6 @@ mod tests {
 
     #[test]
     fn test_delete_screen_should_send_correct_request() {
-        let _lock = lock_test();
-        let _test = set_env(OsString::from("API_TOKEN"), "token");
         let mock_server = MockServer::start();
         mock_server.mock(|when, then| {
             when.method(DELETE)
@@ -182,7 +168,7 @@ mod tests {
         });
 
         let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config);
+        let authentication = Authentication::new_with_config(config, "token");
         let screen_command = ScreenCommand::new(authentication);
         assert!(screen_command.delete("test-id").is_ok());
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -7,7 +7,7 @@ use sha2::Digest;
 use sha2::Sha256;
 use std::fs::File;
 
-use std::io::{Read};
+use std::io::Read;
 use std::path::Path;
 
 pub fn sig_to_hex(signature: &Signature) -> String {


### PR DESCRIPTION
## What does this PR do?
Allows tests to run in parallel. Previously we had to lock them because to override the token we had to set env variable which was not thread-safe.
## How has this been tested?
All tests pass. Manually as well - commands keep working.

## Checklist before merging

- [ ] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
