### PR TITLE
Fix upload not working when path is not passed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,13 @@ fn main() {
 
     let _sentry_dsn = "https://891eb4b6f8ff4f959fd76a587d9ab302@o4505481987489792.ingest.sentry.io/4505482139140096";
 
-    let _guard = sentry::init((_sentry_dsn, sentry::ClientOptions {
-        release: sentry::release_name!(),
-        ..Default::default()
-    }));
+    let _guard = sentry::init((
+        _sentry_dsn,
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            ..Default::default()
+        },
+    ));
 
     let cli = cli::Cli::parse();
     cli::handle_cli(&cli);


### PR DESCRIPTION
## What does this PR do?
Fixes `edge-app upload` command not working when explicit path is not passed.
## GitHub issue or Phabricator ticket number?

## How has this been tested?
Tested the command.
Unit tests for the function working with paths.

## Checklist before merging

- [x] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
