### PR TITLE
Adds: promote cli command.

### DIFF
--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -92,7 +92,6 @@ impl Authentication {
         );
 
         reqwest::blocking::Client::builder()
-            //.danger_accept_invalid_certs(true)
             .default_headers(default_headers)
             .build()
             .map_err(AuthenticationError::Request)
@@ -119,7 +118,6 @@ fn verify_token(token: &str, api_url: &str) -> anyhow::Result<(), Authentication
     let url = format!("{}/v3/groups/11CF9Z3GZR0005XXKH00F8V20R/", api_url);
     let secret = format!("Token {token}");
     let client = reqwest::blocking::Client::builder()
-        //.danger_accept_invalid_certs(true)
         .build()?;
 
     let res = client

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -4,8 +4,11 @@ use reqwest::header::{HeaderMap, InvalidHeaderValue};
 use reqwest::{header, StatusCode};
 use thiserror::Error;
 
-//const API_BASE_URL: &str = "https://api.screenlyappstage.com/api";
+// const API_BASE_URL: &str = "https://api.screenlyappstage.com/api";
 const API_BASE_URL: &str = "https://api.screenlyapp.com/api";
+// use this one for local development
+// but also uncomment unsafe certificate lines "danger_accept_invalid_certs(true)".
+// const API_BASE_URL: &str = "https://login.screenly.local/api";
 
 pub struct Config {
     pub url: String,
@@ -89,6 +92,7 @@ impl Authentication {
         );
 
         reqwest::blocking::Client::builder()
+            //.danger_accept_invalid_certs(true)
             .default_headers(default_headers)
             .build()
             .map_err(AuthenticationError::Request)
@@ -114,7 +118,9 @@ fn verify_token(token: &str, api_url: &str) -> anyhow::Result<(), Authentication
     // Using uuid of non existing playlist. If we get 404 it means we authenticated successfully.
     let url = format!("{}/v3/groups/11CF9Z3GZR0005XXKH00F8V20R/", api_url);
     let secret = format!("Token {token}");
-    let client = reqwest::blocking::Client::builder().build()?;
+    let client = reqwest::blocking::Client::builder()
+        //.danger_accept_invalid_certs(true)
+        .build()?;
 
     let res = client
         .get(url)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -290,6 +290,14 @@ pub enum EdgeAppCommands {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         path: Option<String>,
     },
+
+    Promote {
+        /// Edge app revision to promote.
+        #[arg(short, long)]
+        revision: Option<i32>,
+        /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        path: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -764,6 +772,22 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     ),
                     json,
                 );
+            }
+        },
+        EdgeAppCommands::Promote{path, revision} => {
+            if let Some(_revision) = revision {
+                println!("Revision not specified. Latest revision will be used to promote.");
+            }
+            match edge_app_command.promote(
+                &EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path()).unwrap(),
+                revision
+            ) {
+                Ok(updated) => {
+                    println!("Edge app successfully promoted. Updated playlist items: {updated}.");
+                }
+                Err(e) => {
+                    println!("Failed to promote edge app: {e}.");
+                }
             }
         },
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -294,7 +294,7 @@ pub enum EdgeAppCommands {
     Promote {
         /// Edge app revision to promote.
         #[arg(short, long)]
-        revision: Option<i32>,
+        revision: Option<u32>,
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         path: Option<String>,
     },
@@ -775,12 +775,13 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             }
         },
         EdgeAppCommands::Promote{path, revision} => {
-            if let Some(_revision) = revision {
-                println!("Revision not specified. Latest revision will be used to promote.");
+            let mut manifest = EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path()).unwrap();
+            if revision.is_some() {
+                manifest.revision = revision.unwrap();
+
             }
             match edge_app_command.promote(
-                &EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path()).unwrap(),
-                revision
+                &manifest
             ) {
                 Ok(updated) => {
                     println!("Edge app successfully promoted. Updated playlist items: {updated}.");

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -205,13 +205,15 @@ impl EdgeAppCommand {
             &payload,
         )?;
 
-        if let Some(dict) = response.as_object() {
-            if let Some(revision) = dict.get("updated") {
-                if let Some(revision_value) = revision.as_i64() {
-                    return Ok(revision_value as i32);
-                }
-            }
-        };
+        let updated_amount = response
+            .as_object()
+            .and_then(|dict| dict.get("updated"))
+            .and_then(|_updated| _updated.as_i64())
+            .map(|_updated| _updated as i32);
+
+        if let Some(amount) = updated_amount {
+            return Ok(amount);
+        }
 
         Err(CommandError::MissingField)
     }

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -185,24 +185,15 @@ impl EdgeAppCommand {
         Ok(())
     }
 
-    pub fn promote(&self, manifest: &EdgeAppManifest, version: &Option<i32>) -> Result<i32, CommandError> {
-        let payload = match version {
-            Some(version_value) => json!(
-                {
-                    "revision": version_value,
-                    "app_id": manifest.app_id.clone(),
-                }
-            ),
-            None => json!(
-                {
-                    "app_id": manifest.app_id.clone(),
-                }
-            ),
-        };
+    pub fn promote(&self, manifest: &EdgeAppManifest) -> Result<i32, CommandError> {
         let response = commands::post(
             &self.authentication,
             "v4/edge-apps/promote",
-            &payload,
+            &json!(
+                {
+                    "revision": manifest.revision,
+                    "app_id": manifest.app_id.clone(),
+                }),
         )?;
 
         let updated_amount = response
@@ -819,7 +810,7 @@ mod tests {
                 )
                 .json_body(json!({
                     "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                    "revision": 1,
+                    "revision": 7,
                 }));
             then.status(201)
                 .json_body(json!({"updated": 2}));
@@ -840,47 +831,7 @@ mod tests {
             settings: vec![],
         };
 
-        let result = command.promote(&manifest, &Option::Some(1));
-        edge_apps_mock.assert();
-
-        assert!(&result.is_ok());
-        assert_eq!(&result.unwrap(), &2);
-    }
-
-    #[test]
-    fn test_promote_with_no_revision_should_send_correct_request() {
-        let mock_server = MockServer::start();
-        let edge_apps_mock = mock_server.mock(|when, then| {
-            when.method(POST)
-                .path("/v4/edge-apps/promote")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .json_body(json!({
-                    "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                }));
-            then.status(201)
-                .json_body(json!({"updated": 2}));
-        });
-
-        let config = Config::new(mock_server.base_url());
-        let authentication = Authentication::new_with_config(config, "token");
-        let command = EdgeAppCommand::new(authentication);
-        let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
-            root_asset_id: "".to_string(),
-            user_version: "1".to_string(),
-            revision: 7,
-            description: "asdf".to_string(),
-            icon: "asdf".to_string(),
-            author: "asdf".to_string(),
-            homepage_url: "asdfasdf".to_string(),
-            settings: vec![],
-        };
-
-        let result = command.promote(&manifest, &Option::None);
+        let result = command.promote(&manifest);
         edge_apps_mock.assert();
 
         assert!(&result.is_ok());

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -201,7 +201,7 @@ impl EdgeAppCommand {
         };
         let response = commands::post(
             &self.authentication,
-            &format!("v4/edge-apps/promote"),
+            "v4/edge-apps/promote",
             &payload,
         )?;
 


### PR DESCRIPTION
## What does this PR do?
- Adds cli command edge app promote 
```
screenly edge-app promote --help        
Usage: screenly edge-app promote [OPTIONS] [PATH]

Arguments:
  [PATH]  Path to the directory with the manifest. If not specified CLI will use the current working directory

Options:
  -r, --revision <REVISION>  Edge app revision to promote
  -h, --help                 Print help
  -V, --version              Print version
```

- Adds optional commented lines for local development(with local screenly pro)
## GitHub issue or Phabricator ticket number?
https://ph.wireload.net/T7147

## How has this been tested?
Manuall on local environment and unit tests

## Checklist before merging

- [x] If have added tests.
- [x] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
