### PR TITLE
Edits: for initialized files on edge-app create

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -2,19 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <script src="screenly.js"></script>
     <title>Hello world</title>
+    <script src="screenly.js?version=1"></script>
   </head>
   <body>
-    <p id="message">Hello world from <span id="hostname-placeholder"></span></p>
-    <script>
-      fetch(screenlyMetadataEndpoint())
-        .then((response) => response.json())
-        .then((data) => {
-          const hostname = data.hostname;
-          const hostnamePlaceholder = document.getElementById("hostname-placeholder");
-          hostnamePlaceholder.innerText = hostname;
-        });
-    </script>
+    <p id="message">Hello world from <span id="username-placeholder"></span></p>
   </body>
+  <script>
+    const usernamePlaceholder = document.getElementById("username-placeholder");
+    usernamePlaceholder.innerText = screenly.settings.username;
+  </script>
 </html>

--- a/data/index.html
+++ b/data/index.html
@@ -6,10 +6,11 @@
     <script src="screenly.js?version=1"></script>
   </head>
   <body>
-    <p id="message">Hello world from <span id="username-placeholder"></span></p>
+    <p>Hi <span id="username"></span>,</p>
+    <p>I'm <span id="screen-name"></span>.</p>
   </body>
   <script>
-    const usernamePlaceholder = document.getElementById("username-placeholder");
-    usernamePlaceholder.innerText = screenly.settings.username;
+    document.getElementById("username").innerText = screenly.settings.username;
+    document.getElementById("screen-name").innerText = screenly.metadata.screen_name;
   </script>
 </html>

--- a/data/index.html
+++ b/data/index.html
@@ -10,7 +10,7 @@
     <p>I'm <span id="screen-name"></span>.</p>
   </body>
   <script>
-    document.getElementById("username").innerText = screenly.settings.username;
+    document.getElementById("username").innerText = screenly.settings.username || "stranger";
     document.getElementById("screen-name").innerText = screenly.metadata.screen_name;
   </script>
 </html>

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -78,7 +78,7 @@ impl EdgeAppCommand {
                 title: "username".to_string(),
                 type_: "text".to_string(),
                 default_value: "stranger".to_string(),
-                optional: false,
+                optional: true,
                 help_text: "An example of a setting that is used in index.html".to_string()
             }],
             ..Default::default()
@@ -708,7 +708,7 @@ mod tests {
             title: "username".to_string(),
             type_: "text".to_string(),
             default_value: "stranger".to_string(),
-            optional: false,
+            optional: true,
             help_text: "An example of a setting that is used in index.html".to_string()
         }]);
 

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -62,6 +62,13 @@ impl EdgeAppCommand {
 
         let manifest = EdgeAppManifest {
             app_id,
+            settings: vec![Setting {
+                title: "username".to_string(),
+                type_: "text".to_string(),
+                default_value: "screenly".to_string(),
+                optional: false,
+                help_text: "An example of a setting that is used in index.html".to_string()
+            }],
             ..Default::default()
         };
 
@@ -691,6 +698,13 @@ mod tests {
         let data = fs::read_to_string(tmp_dir.path().join("screenly.yml")).unwrap();
         let manifest: EdgeAppManifest = serde_yaml::from_str(&data).unwrap();
         assert_eq!(manifest.app_id, "test-id");
+        assert_eq!(manifest.settings, vec![Setting {
+            title: "username".to_string(),
+            type_: "text".to_string(),
+            default_value: "screenly".to_string(),
+            optional: false,
+            help_text: "An example of a setting that is used in index.html".to_string()
+        }]);
 
         let data_index_html = fs::read_to_string(tmp_dir.path().join("index.html")).unwrap();
         assert_eq!(data_index_html, include_str!("../../data/index.html"));


### PR DESCRIPTION
Ticket: https://ph.wireload.net/T7251

Edits:
- Updated index.html using updated screenly.js (settings and metadata)
- Added a default setting(username) to manifest that is used by the index.html
- Added validation that manifest and index.html do not exist on `edge-app create`

Screenshot of testing on the viewer:
![Screenshot from 2023-08-08 18-02-03](https://github.com/Screenly/cli/assets/17593028/6f0f6e76-cc8c-471c-9216-84f5c419b714)


