### PR TITLE
Adds: settings single secret command

### DIFF
--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -512,8 +512,8 @@ impl EdgeAppCommand {
 
         debug!("Creating setting: {:?}", &payload);
 
-        let _response = commands::post(&self.authentication, "v4/edge-apps/settings", &payload);
-        if _response.is_err() {
+        let response = commands::post(&self.authentication, "v4/edge-apps/settings", &payload);
+        if response.is_err() {
             let c = commands::get(
                 &self.authentication,
                 &format!("v4/edge-apps/settings?app_id=eq.{}", manifest.app_id),

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -114,7 +114,7 @@ pub fn detect_changed_settings(
     let new_settings = &manifest.settings;
 
     let mut creates = Vec::new();
-    let mut updates = Vec:: new();
+    let mut updates = Vec::new();
 
     let mut remote_iter = remote_settings.iter().peekable();
     let mut new_iter = new_settings.iter().peekable();
@@ -127,7 +127,6 @@ pub fn detect_changed_settings(
                 }
                 remote_iter.next();
                 new_iter.next();
-
             }
             std::cmp::Ordering::Less => {
                 remote_iter.next();
@@ -141,10 +140,7 @@ pub fn detect_changed_settings(
 
     creates.extend(new_iter.cloned());
 
-    Ok(SettingChanges {
-        creates,
-        updates
-    })
+    Ok(SettingChanges { creates, updates })
 }
 
 pub fn generate_file_tree(files: &[EdgeAppFile], root_path: &Path) -> HashMap<String, String> {


### PR DESCRIPTION
Refs https://phorge.wireload.net/T7243

Adds setting single secret command using global settings/secrets.
Works same as settings.
`screenly edge-app secret set key=value`

Also used fmt code command.