### PR TITLE
Adds: promote version to channel command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -306,6 +306,7 @@ pub enum EdgeAppVersionCommands {
     },
     Promote {
         /// Edge app revision to promote.
+        #[arg(short, long)]
         revision: u32,
         /// Channel to promote to. Stable by default
         #[arg(short, long, default_value = "stable")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -293,14 +293,6 @@ pub enum EdgeAppCommands {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         path: Option<String>,
     },
-
-    Promote {
-        /// Edge app revision to promote.
-        #[arg(short, long)]
-        revision: Option<u32>,
-        /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
-        path: Option<String>,
-    },
 }
 
 #[derive(Subcommand, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -311,6 +303,15 @@ pub enum EdgeAppVersionCommands {
         /// Enables JSON output.
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
         json: Option<bool>,
+    },
+    Promote {
+        /// Edge app revision to promote.
+        revision: u32,
+        /// Channel to promote to. Stable by default
+        #[arg(short, long, default_value = "stable")]
+        channel: String,
+        /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        path: Option<String>,
     },
 }
 
@@ -788,6 +789,25 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     json,
                 );
             }
+            EdgeAppVersionCommands::Promote {
+                path,
+                revision,
+                channel,
+            } => {
+                match edge_app_command.promote_version(
+                    &EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path())
+                        .unwrap(),
+                    revision,
+                    channel,
+                ) {
+                    Ok(()) => {
+                        println!("Edge app version successfully promoted.");
+                    }
+                    Err(e) => {
+                        println!("Failed to promote edge app version: {e}.");
+                    }
+                }
+            }
         },
         EdgeAppCommands::Setting(command) => match command {
             EdgeAppSettingsCommands::List { path, json } => {
@@ -832,21 +852,6 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 }
             }
         },
-        EdgeAppCommands::Promote { path, revision } => {
-            let mut manifest =
-                EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path()).unwrap();
-            if revision.is_some() {
-                manifest.revision = revision.unwrap();
-            }
-            match edge_app_command.promote(&manifest) {
-                Ok(updated) => {
-                    println!("Edge app successfully promoted. Updated playlist items: {updated}.");
-                }
-                Err(e) => {
-                    println!("Failed to promote edge app: {e}.");
-                }
-            }
-        }
     }
 }
 

--- a/src/commands/asset.rs
+++ b/src/commands/asset.rs
@@ -105,7 +105,8 @@ impl AssetCommand {
     ) -> anyhow::Result<(), CommandError> {
         let endpoint = format!("v4/assets?id=eq.{id}");
         let map: HashMap<_, _> = headers.into_iter().collect();
-        commands::patch(&self.authentication, &endpoint, &json!({ "headers": map }))
+        commands::patch(&self.authentication, &endpoint, &json!({ "headers": map }))?;
+        Ok(())
     }
 
     pub fn update_web_asset_headers(
@@ -144,7 +145,8 @@ impl AssetCommand {
             &self.authentication,
             &endpoint,
             &json!({ "js_injection": js_code }),
-        )
+        )?;
+        Ok(())
     }
 
     pub fn delete(&self, id: &str) -> anyhow::Result<(), CommandError> {

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -301,28 +301,25 @@ impl EdgeAppCommand {
         Ok(())
     }
 
-    pub fn promote(&self, manifest: &EdgeAppManifest) -> Result<i32, CommandError> {
-        let response = commands::post(
+    pub fn promote_version(
+        &self,
+        manifest: &EdgeAppManifest,
+        revision: &u32,
+        channel: &String,
+    ) -> Result<(), CommandError> {
+        commands::patch(
             &self.authentication,
-            "v4/edge-apps/promote",
+            &format!(
+                "v4/edge-apps/channels?channel=eq.{}&app_id=eq.{}",
+                channel, manifest.app_id
+            ),
             &json!(
             {
-                "revision": manifest.revision,
-                "app_id": manifest.app_id.clone(),
+                "app_revision": revision,
             }),
         )?;
 
-        let updated_amount = response
-            .as_object()
-            .and_then(|dict| dict.get("updated"))
-            .and_then(|_updated| _updated.as_i64())
-            .map(|_updated| _updated as i32);
-
-        if let Some(amount) = updated_amount {
-            return Ok(amount);
-        }
-
-        Err(CommandError::MissingField)
+        Ok(())
     }
 
     fn create_version(
@@ -1507,19 +1504,20 @@ mod tests {
     #[test]
     fn test_promote_should_send_correct_request() {
         let mock_server = MockServer::start();
-        let edge_apps_mock = mock_server.mock(|when, then| {
-            when.method(POST)
-                .path("/v4/edge-apps/promote")
+        let promote_mock = mock_server.mock(|when, then| {
+            when.method(PATCH)
+                .path("/v4/edge-apps/channels")
                 .header("Authorization", "Token token")
                 .header(
                     "user-agent",
                     format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
                 )
+                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
+                .query_param("channel", "eq.public")
                 .json_body(json!({
-                    "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                    "revision": 7,
+                    "app_revision": 7,
                 }));
-            then.status(201).json_body(json!({"updated": 2}));
+            then.status(200).json_body(json!([]));
         });
 
         let config = Config::new(mock_server.base_url());
@@ -1537,10 +1535,9 @@ mod tests {
             settings: vec![],
         };
 
-        let result = command.promote(&manifest);
-        edge_apps_mock.assert();
+        let result = command.promote_version(&manifest, &7, &"public".to_string());
+        promote_mock.assert();
 
         assert!(&result.is_ok());
-        assert_eq!(&result.unwrap(), &2);
     }
 }


### PR DESCRIPTION
Refs https://phorge.wireload.net/T7132

Adds versions promote command.
`screenly edge-app version promote 2  .`

Note: I now we will replace path with app_id, but this is not the point ot this pr, so added path for now.