### PR TITLE
Fix: upload file against appserver

### DIFF
--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -612,9 +612,6 @@ impl EdgeAppCommand {
         let mut headers = HeaderMap::new();
         headers.insert("Prefer", "return=representation".parse()?);
 
-        let file = File::open(path)?;
-        let part = reqwest::blocking::multipart::Part::reader(file).file_name("file");
-
         debug!("Uploading file: {:?}", path);
         let form = reqwest::blocking::multipart::Form::new()
             .text(
@@ -628,7 +625,7 @@ impl EdgeAppCommand {
             )
             .text("app_id", manifest.app_id.clone())
             .text("app_revision", manifest.revision.to_string())
-            .part("file", part);
+            .file("file", path)?;
 
         let response = self
             .authentication


### PR DESCRIPTION
Ticket: https://phorge.wireload.net/T7239

Nginx error:
```
nginx_1                  | 2023/08/18 09:37:34 [error] 8#8: *187 lua entry thread aborted: runtime error: ...eenly/maybe_upload_file_to_s3_on_post_assets_request.lua:70: chunked request bodies not supported yet
nginx_1                  | stack traceback:
nginx_1                  | coroutine 0:
nginx_1                  |      [C]: in function 'assert'
nginx_1                  |      ...eenly/maybe_upload_file_to_s3_on_post_assets_request.lua:70: in main chunk
nginx_1                  |      access_by_lua(/etc/nginx/conf.d/appserver.conf:340):14: in main chunk, client: 192.168.80.1, server: ~^(?<subdomain>[^.]+)\.(?<domain>.+), request: "POST /api/v4/assets HTTP/1.1", host: "api.screenly.local"
nginx_1                  | 2023/08/18 09:37:34 [error] 8#8: *187 [lua] appserver.conf:238):25: Error happened while handling response postgrest error ...openresty/nginx/../lualib/screenly/error_handlers_v4.lua:149: Expected value but found invalid token at character 1<html>
nginx_1                  | <head><title>500 Internal Server Error</title></head>
nginx_1                  | <body>
nginx_1                  | <center><h1>500 Internal Server Error</h1></center>
nginx_1                  | <hr><center>openresty</center>
nginx_1                  | </body>
nginx_1                  | </html>
nginx_1                  | , client: 192.168.80.1, server: ~^(?<subdomain>[^.]+)\.(?<domain>.+), request: "POST /api/v4/assets HTTP/1.1", host: "api.screenly.local"
nginx_1                  | 192.168.80.1 - - [18/Aug/2023:09:37:34 +0000] "POST /api/v4/assets HTTP/1.1" 500 5 "-" "screenly-cli 0.1.4"
```

Description:
At the current moment, the CLI upload command doesn't work if we ignore Cloudflare since nginx-lua doesn't support chunked requests. I guess that Cloudflare reads a request body fully before passing it to nginx, thus, the body is passed without a header "Transfer-Encoding: chunked". Anyhow it should work properly w/out any proxy server.

Tests:
- Tested against local build and stage