### PR TITLE
Workflow changes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -266,6 +266,7 @@ pub enum EdgeAppCommands {
         /// Edge app name
         name: String,
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        #[arg(short, long)]
         path: Option<String>,
     },
 
@@ -291,7 +292,12 @@ pub enum EdgeAppCommands {
     /// Uploads assets and settings of the edge app.
     Upload {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        #[arg(short, long)]
         path: Option<String>,
+
+        /// Edge app id. If not specified CLI will use the id from the manifest.
+        #[arg(short, long)]
+        app_id: Option<String>,
     },
 }
 
@@ -299,6 +305,7 @@ pub enum EdgeAppCommands {
 pub enum EdgeAppVersionCommands {
     List {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        #[arg(short, long)]
         path: Option<String>,
         /// Enables JSON output.
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
@@ -308,10 +315,11 @@ pub enum EdgeAppVersionCommands {
         /// Edge app revision to promote.
         #[arg(short, long)]
         revision: u32,
-        /// Channel to promote to. Stable by default
+        /// Channel to promote to. If not specified CLI will use stable channel.
         #[arg(short, long, default_value = "stable")]
         channel: String,
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        #[arg(short, long)]
         path: Option<String>,
     },
 }
@@ -320,7 +328,13 @@ pub enum EdgeAppVersionCommands {
 pub enum EdgeAppSettingsCommands {
     List {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        #[arg(short, long)]
         path: Option<String>,
+
+        /// Edge app id. If not specified CLI will use the id from the manifest.
+        #[arg(short, long)]
+        app_id: Option<String>,
+
         /// Enables JSON output.
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
         json: Option<bool>,
@@ -330,7 +344,13 @@ pub enum EdgeAppSettingsCommands {
         /// Key value pair of the setting to be set in the form of `key=value`.
         #[arg(value_parser = parse_key_val)]
         setting_pair: (String, String),
+
+        /// Edge app id. If not specified CLI will use the id from the manifest.
+        #[arg(short, long)]
+        app_id: Option<String>,
+
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        #[arg(short, long)]
         path: Option<String>,
     },
 }
@@ -341,7 +361,13 @@ pub enum EdgeAppSecretsCommands {
         /// Key value pair of the secret to be set in the form of `key=value`.
         #[arg(value_parser = parse_key_val)]
         secret_pair: (String, String),
+
+        /// Edge app id. If not specified CLI will use the id from the manifest.
+        #[arg(short, long)]
+        app_id: Option<String>,
+
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        #[arg(short, long)]
         path: Option<String>,
     },
 }
@@ -395,6 +421,17 @@ pub fn get_screen_name(
     }
 
     Err(CommandError::MissingField)
+}
+
+fn get_actual_app_id(app_id: &Option<String>, path: &Option<String>) -> String {
+    match app_id {
+        Some(id) => id.clone(),
+        None => {
+            let manifest =
+                EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path()).unwrap();
+            manifest.app_id.clone()
+        }
+    }
 }
 
 pub fn get_asset_title(
@@ -772,10 +809,16 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
         EdgeAppCommands::List { json } => {
             handle_command_execution_result(edge_app_command.list(), json);
         }
-        EdgeAppCommands::Upload { path } => {
-            match edge_app_command.upload(transform_edge_app_path_to_manifest(path).as_path()) {
-                Ok(()) => {
-                    println!("Edge app successfully uploaded.");
+        EdgeAppCommands::Upload { path, app_id } => {
+            match edge_app_command.upload(
+                transform_edge_app_path_to_manifest(path).as_path(),
+                app_id.clone(),
+            ) {
+                Ok(revision) => {
+                    println!(
+                        "Edge app successfully uploaded. Revision: {revision}.",
+                        revision = revision
+                    );
                 }
                 Err(e) => {
                     println!("Failed to upload edge app: {e}.");
@@ -811,44 +854,44 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             }
         },
         EdgeAppCommands::Setting(command) => match command {
-            EdgeAppSettingsCommands::List { path, json } => {
+            EdgeAppSettingsCommands::List { path, json, app_id } => {
+                let actual_app_id = get_actual_app_id(app_id, path);
                 handle_command_execution_result(
-                    edge_app_command.list_settings(
-                        &EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path())
-                            .unwrap(),
-                    ),
+                    edge_app_command.list_settings(&actual_app_id),
                     json,
                 );
             }
-            EdgeAppSettingsCommands::Set { setting_pair, path } => {
-                match edge_app_command.set_setting(
-                    &EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path())
-                        .unwrap(),
-                    &setting_pair.0,
-                    &setting_pair.1,
-                ) {
+            EdgeAppSettingsCommands::Set {
+                setting_pair,
+                app_id,
+                path,
+            } => {
+                let actual_app_id = get_actual_app_id(app_id, path);
+                match edge_app_command.set_setting(&actual_app_id, &setting_pair.0, &setting_pair.1)
+                {
                     Ok(()) => {
                         println!("Edge app setting successfully set.");
                     }
                     Err(e) => {
-                        println!("Failed to set edge app setting: {e}.");
+                        println!("Failed to set edge app setting: {}", e);
                     }
                 }
             }
         },
         EdgeAppCommands::Secret(command) => match command {
-            EdgeAppSecretsCommands::Set { secret_pair, path } => {
-                match edge_app_command.set_secret(
-                    &EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path())
-                        .unwrap(),
-                    &secret_pair.0,
-                    &secret_pair.1,
-                ) {
+            EdgeAppSecretsCommands::Set {
+                secret_pair,
+                app_id,
+                path,
+            } => {
+                let actual_app_id = get_actual_app_id(app_id, path);
+
+                match edge_app_command.set_secret(&actual_app_id, &secret_pair.0, &secret_pair.1) {
                     Ok(()) => {
                         println!("Edge app secret successfully set.");
                     }
                     Err(e) => {
-                        println!("Failed to set edge app secret: {e}.");
+                        println!("Failed to set edge app secret: {}", e);
                     }
                 }
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -440,7 +440,7 @@ fn get_actual_app_id(app_id: &Option<String>, path: &Option<String>) -> String {
         None => {
             let manifest =
                 EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path()).unwrap();
-            manifest.app_id.clone()
+            manifest.app_id
         }
     }
 }

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -86,9 +86,7 @@ impl EdgeAppCommand {
             ..Default::default()
         };
 
-        let yaml = serde_yaml::to_string(&manifest)?;
-        let manifest_file = File::create(path)?;
-        write!(&manifest_file, "{yaml}")?;
+        EdgeAppManifest::save_to_file(&manifest, path)?;
 
         let index_html_template = include_str!("../../data/index.html");
         let index_html_file = File::create(&index_html_path)?;

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -163,7 +163,6 @@ mod tests {
     fn create_manifest() -> EdgeAppManifest {
         EdgeAppManifest {
             app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
-            root_asset_id: "".to_string(),
             user_version: "1".to_string(),
             revision: 7,
             description: "asdf".to_string(),

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -164,7 +164,6 @@ mod tests {
         EdgeAppManifest {
             app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
             user_version: "1".to_string(),
-            revision: 7,
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
             author: "asdf".to_string(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -202,7 +202,6 @@ pub fn patch<T: Serialize + ?Sized>(
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EdgeAppManifest {
     pub app_id: String,
-    pub revision: u32,
     pub user_version: String,
     pub description: String,
     pub icon: String,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -202,17 +202,17 @@ pub fn patch<T: Serialize + ?Sized>(
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EdgeAppManifest {
     pub app_id: String,
-    #[serde(default)]
-    pub root_asset_id: String,
-    pub user_version: String,
-    #[serde(default)]
     pub revision: u32,
+    pub user_version: String,
     pub description: String,
     pub icon: String,
     pub author: String,
     pub homepage_url: String,
-    #[serde(serialize_with = "serialize_settings")]
-    #[serde(deserialize_with = "deserialize_settings", default)]
+    #[serde(
+        serialize_with = "serialize_settings",
+        deserialize_with = "deserialize_settings",
+        default
+    )]
     pub settings: Vec<Setting>,
 }
 


### PR DESCRIPTION
## What does this PR do?
Adds app_id parameter that allows to override used app id.
The path is now named argument.
Got rid of root_asset_id and revision in the manifest file. 

## GitHub issue or Phabricator ticket number?
T7251

## How has this been tested?
Tests updated
## Checklist before merging

- [ ] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
