### PR TITLE
Fix: upload client timeout

### DIFF
--- a/src/commands/asset.rs
+++ b/src/commands/asset.rs
@@ -9,6 +9,7 @@ use reqwest::StatusCode;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs::File;
+use std::time::Duration;
 
 pub struct AssetCommand {
     authentication: Authentication,
@@ -88,6 +89,7 @@ impl AssetCommand {
             .post(url)
             .multipart(form)
             .headers(headers)
+            .timeout(Duration::from_secs(3600))  // timeout is equal to server timeout
             .send()?;
 
         if response.status() != StatusCode::CREATED {

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -644,6 +644,7 @@ impl EdgeAppCommand {
             .post(url)
             .multipart(form)
             .headers(headers)
+            .timeout(Duration::from_secs(3600))  // timeout is equal to server timeout
             .send()?;
 
         let status = response.status();


### PR DESCRIPTION
## What does this PR do?
Fix for the error:
```
Failed to upload edge app: request error: error sending request for url (https://api.screenlyapp.com/api/v4/assets): operation timed out.
```

Edits:
- Added a client timeout equals to 1 hour. It's a value that the server allows to keep the connection on the upload endpoint.

## GitHub issue or Phabricator ticket number?
https://phorge.wireload.net/T7309

## How has this been tested?
Manually on production

## Checklist before merging

- [ ] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
