### PR TITLE
Fix: progress bar set_position instead of set_length

### DIFF
--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -468,7 +468,7 @@ impl EdgeAppCommand {
                 }
                 match &mut pb {
                     Some(ref mut progress_bar) => {
-                        progress_bar.set_length(assets_to_process - (array.len() as u64));
+                        progress_bar.set_position(assets_to_process - (array.len() as u64));
                         progress_bar.set_message("Processing Items:");
                     }
                     None => {


### PR DESCRIPTION
Used wrong function for pb - set_position is the right one to set progress, while set_length sets total length.