### PR TITLE
T7350 yml verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,52 @@ with:
   screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
   cli_commands: screen list
 ```
+
+## Verifying YAML Configuration
+
+### Introduction
+The `verify_screenly_yml.sh` script is a utility that validates the `screenly.yml` file against a predefined JSON schema. This ensures that your configuration adheres to the expected format before deploying or using the application.
+
+### Prerequisites
+Before running the script, make sure you have the following installed:
+
+- `Python 3.x`
+- `jsonschema` Python package
+
+You can install the jsonschema package using pip:
+
+```bash
+pip3 install jsonschema
+```
+
+### Directory Structure
+Your project should have the following directory structure for the script to work correctly:
+
+- `cli/` is the root directory,
+- `cli/schema/` contains the JSON schema file `screenly_yml_schema.json`,
+- `cli/scripts/` contains the script `verify_screenly_yml.sh`.
+
+### Running the Script
+Navigate to the root directory (`cli/`).
+Run the following command:
+
+```bash
+./scripts/verify_screenly_yml.sh ./screenly.yml
+```
+Replace `./screenly.yml` with the path to your YAML file if it is located elsewhere.
+
+Output
+Upon successful validation, you'll see:
+
+```
+Validation successful!
+```
+
+If validation fails, you'll get an error message for each issue indicating the property that caused the failure and its location:
+
+```
+Validation failed!
+  Error at []: 'app_id' is a required property
+  Error at ['settings', 'username', 'optional']: 'asdqwe123' is not of type 'boolean'
+  Error at ['settings', 'username', 'type']: True is not of type 'string'
+```

--- a/schema/screenly_yml_schema.json
+++ b/schema/screenly_yml_schema.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+      "app_id": {
+        "type": "string",
+        "pattern": "^[0-9A-Z]+$"
+      },
+      "user_version": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "icon": {
+        "type": "string"
+      },
+      "author": {
+        "type": "string"
+      },
+      "homepage_url": {
+        "type": "string",
+        "format": "uri"
+      },
+      "settings": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "object",
+            "properties": {
+              "default_value": {
+                "type": "string"
+              },
+              "help_text": {
+                "type": "string"
+              },
+              "optional": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": ["type", "default_value", "title", "optional", "help_text"]
+          }
+        },
+        "required": ["username"]
+      }
+    },
+    "required": ["app_id", "settings"]
+  } 

--- a/scripts/verify_screenly_yml.sh
+++ b/scripts/verify_screenly_yml.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 # Validate YAML against JSON Schema.
 
+# Exit codes
+SUCCESS=0
+ERR_USAGE=1
+ERR_VALIDATION_FAILED=2
+
 if [[ -z "$1" ]]; then
   echo "Usage: $0 <PATH_TO_YAML_FILE>"
-  exit 1
+  exit $ERR_USAGE
 fi
 
 SCHEMA_PATH="./schema/screenly_yml_schema.json"
-
-if [[ ! "$SCHEMA_PATH" = /* ]]; then
-  SCHEMA_PATH="$(cd "$(dirname "$SCHEMA_PATH")" && pwd)/$(basename "$SCHEMA_PATH")"
-fi
 
 python3 - <<END
 import os
@@ -34,7 +35,12 @@ if errors:
     print("Validation failed!")
     for error in errors:
         print(f"  Error at {list(error.path)}: {error.message}")
+    exit($ERR_VALIDATION_FAILED)
 else:
     print("Validation successful!")
-
+    exit($SUCCESS)
 END
+
+PYTHON_EXIT_CODE=$?
+
+exit $PYTHON_EXIT_CODE

--- a/scripts/verify_screenly_yml.sh
+++ b/scripts/verify_screenly_yml.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Validate YAML against JSON Schema.
+
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 <PATH_TO_YAML_FILE>"
+  exit 1
+fi
+
+SCHEMA_PATH="./schema/screenly_yml_schema.json"
+
+if [[ ! "$SCHEMA_PATH" = /* ]]; then
+  SCHEMA_PATH="$(cd "$(dirname "$SCHEMA_PATH")" && pwd)/$(basename "$SCHEMA_PATH")"
+fi
+
+python3 - <<END
+import os
+import json
+import yaml
+from jsonschema import Draft4Validator
+
+yaml_file_path = os.path.abspath("$1")
+json_schema_path = "$SCHEMA_PATH"
+
+with open(yaml_file_path, 'r') as f:
+    yaml_data = yaml.safe_load(f)
+
+with open(json_schema_path, 'r') as f:
+    schema = json.load(f)
+
+validator = Draft4Validator(schema)
+errors = sorted(validator.iter_errors(yaml_data), key=lambda e: e.path)
+
+if errors:
+    print("Validation failed!")
+    for error in errors:
+        print(f"  Error at {list(error.path)}: {error.message}")
+else:
+    print("Validation successful!")
+
+END


### PR DESCRIPTION
## What does this PR do?
https://phorge.wireload.net/T7350

This PR adds a `screenly.yml` verification script that uses schema similar to one that `snapcraft` uses (https://github.com/snapcore/snapcraft/blob/main/schema/snapcraft.json).

Script can be used to check if all required fields are present in `screenly.yml` and if their type is correct. The script returns exit code according to verification result for use in the CI and also prints all issues found in the `.yml. file.

## How has this been tested?
- Manual tests with `screenly.yml` that is created by the `CLI`