### PR TITLE
Adds: check undefined secrets on promote.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -332,9 +332,6 @@ pub enum EdgeAppVersionCommands {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         #[arg(short, long)]
         path: Option<String>,
-
-        #[arg(short, long, action=clap::ArgAction::SetTrue, default_value = "false")]
-        ignore_warnings: Option<bool>,
     },
 }
 
@@ -854,15 +851,9 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 revision,
                 app_id,
                 channel,
-                ignore_warnings,
             } => {
                 let actual_app_id = get_actual_app_id(app_id, path);
-                match edge_app_command.promote_version(
-                    &actual_app_id,
-                    revision,
-                    channel,
-                    ignore_warnings.unwrap(),
-                ) {
+                match edge_app_command.promote_version(&actual_app_id, revision, channel) {
                     Ok(()) => {
                         println!("Edge app version successfully promoted.");
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -332,6 +332,9 @@ pub enum EdgeAppVersionCommands {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         #[arg(short, long)]
         path: Option<String>,
+
+        #[arg(short, long, action=clap::ArgAction::SetTrue, default_value = "false")]
+        ignore_warnings: Option<bool>,
     },
 }
 
@@ -851,9 +854,15 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 revision,
                 app_id,
                 channel,
+                ignore_warnings,
             } => {
                 let actual_app_id = get_actual_app_id(app_id, path);
-                match edge_app_command.promote_version(&actual_app_id, revision, channel) {
+                match edge_app_command.promote_version(
+                    &actual_app_id,
+                    revision,
+                    channel,
+                    ignore_warnings.unwrap(),
+                ) {
                     Ok(()) => {
                         println!("Edge app version successfully promoted.");
                     }

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -306,12 +306,12 @@ impl EdgeAppCommand {
     ) -> Result<(), CommandError> {
         let secrets = self.get_undefined_secrets(app_id)?;
         if !secrets.is_empty() {
-            return Err(CommandError::WarningUndefinedSecrets(
+            return Err(CommandError::UndefinedSecrets(
                 serde_json::to_string(&secrets)?,
             ));
         }
 
-        debug!("No undefined secrets found");
+        debug!("All secrets are defined.");
 
         let response = commands::patch(
             &self.authentication,

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -1741,6 +1741,6 @@ mod tests {
         undefined_secrets_mock.assert();
 
         assert!(!&result.is_ok());
-        assert!(result.unwrap_err().to_string().contains("Warning: these secrets are undefined: [\"undefined_secret\",\"another_undefined_secret\"]. Use --ignore-warning to ignore"));
+        assert!(result.unwrap_err().to_string().contains("Warning: these secrets are undefined: [\"undefined_secret\",\"another_undefined_secret\"]."));
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -101,6 +101,8 @@ pub enum CommandError {
     FileSystemError(String),
     #[error("Asset processing timeout")]
     AssetProcessingTimeout,
+    #[error("Warning: these secrets are undefined: {0}. Use --ignore-warning to ignore")]
+    WarningUndefinedSecrets(String),
 }
 
 pub fn get(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -101,7 +101,7 @@ pub enum CommandError {
     FileSystemError(String),
     #[error("Asset processing timeout")]
     AssetProcessingTimeout,
-    #[error("Warning: these secrets are undefined: {0}. Use --ignore-warning to ignore")]
+    #[error("Warning: these secrets are undefined: {0}.")]
     WarningUndefinedSecrets(String),
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -102,7 +102,7 @@ pub enum CommandError {
     #[error("Asset processing timeout")]
     AssetProcessingTimeout,
     #[error("Warning: these secrets are undefined: {0}.")]
-    WarningUndefinedSecrets(String),
+    UndefinedSecrets(String),
 }
 
 pub fn get(


### PR DESCRIPTION
Refs https://phorge.wireload.net/T7376

Before promote we do check if some secrets are undefined.
```
screenly edge-app version promote --revision 1
Failed to promote edge app version: Warning: these secrets are undefined: ["greeting1","greeting2"]..
```