### PR TITLE
Added: a new create option for create edge-app with existing directory

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -261,7 +261,7 @@ pub enum AssetCommands {
 
 #[derive(Subcommand, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EdgeAppCommands {
-    /// Creates edge-app in the store.
+    /// Creates Edge App in the store.
     Create {
         /// Edge app name
         #[arg(short, long)]
@@ -269,16 +269,9 @@ pub enum EdgeAppCommands {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         #[arg(short, long)]
         path: Option<String>,
-    },
-
-    /// Init an existing edge-app directory with the manifest and index.html.
-    Init {
-        /// Edge app name
-        #[arg(short, long)]
-        name: String,
-        /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
-        #[arg(short, long)]
-        path: Option<String>,
+        /// Initialize an existing Edge App directory with the manifest and index.html.
+        #[arg(short, long, action = clap::ArgAction::SetTrue)]
+        in_place: Option<bool>,
     },
 
     /// Lists your edge apps.
@@ -816,21 +809,14 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
     let edge_app_command = commands::edge_app::EdgeAppCommand::new(authentication);
 
     match command {
-        EdgeAppCommands::Create { name, path } => {
-            match edge_app_command.create(name, transform_edge_app_path_to_manifest(path).as_path())
-            {
-                Ok(()) => {
-                    println!("Edge app successfully created.");
-                }
-                Err(e) => {
-                    println!("Failed to publish edge app manifest: {e}.");
-                    std::process::exit(1);
-                }
-            }
-        }
+        EdgeAppCommands::Create { name, path, in_place } => {
+            let create_func = if in_place.unwrap_or(false) {
+                commands::edge_app::EdgeAppCommand::create_in_place
+            } else {
+                commands::edge_app::EdgeAppCommand::create
+            };
 
-        EdgeAppCommands::Init { name, path } => {
-            match edge_app_command.init(name, transform_edge_app_path_to_manifest(path).as_path())
+            match create_func(&edge_app_command, name, transform_edge_app_path_to_manifest(path).as_path())
             {
                 Ok(()) => {
                     println!("Edge app successfully created.");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,6 +271,16 @@ pub enum EdgeAppCommands {
         path: Option<String>,
     },
 
+    /// Init an existing edge-app directory with the manifest and index.html.
+    Init {
+        /// Edge app name
+        #[arg(short, long)]
+        name: String,
+        /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
+        #[arg(short, long)]
+        path: Option<String>,
+    },
+
     /// Lists your edge apps.
     List {
         /// Enables JSON output.
@@ -818,6 +828,20 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 }
             }
         }
+
+        EdgeAppCommands::Init { name, path } => {
+            match edge_app_command.init(name, transform_edge_app_path_to_manifest(path).as_path())
+            {
+                Ok(()) => {
+                    println!("Edge app successfully created.");
+                }
+                Err(e) => {
+                    println!("Failed to publish edge app manifest: {e}.");
+                    std::process::exit(1);
+                }
+            }
+        }
+
         EdgeAppCommands::List { json } => {
             handle_command_execution_result(edge_app_command.list(), json);
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -269,7 +269,7 @@ pub enum EdgeAppCommands {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         #[arg(short, long)]
         path: Option<String>,
-        /// Initialize an existing Edge App directory with the manifest and index.html.
+        /// Use an existing Edge App directory with the manifest and index.html.
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
         in_place: Option<bool>,
     },

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -112,7 +112,7 @@ impl EdgeAppCommand {
         let mut manifest: EdgeAppManifest = serde_yaml::from_str(&data)?;
 
         if !manifest.app_id.is_empty() {
-            return Err(CommandError::FileSystemError("app_id in screenly.yml must be empty".to_string()));
+            return Err(CommandError::FileSystemError("app_id in screenly.yml should not be set".to_string()));
         }
 
         let response = commands::post(
@@ -984,7 +984,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Filesystem error: app_id in screenly.yml must be empty"
+            "Filesystem error: app_id in screenly.yml should not be set"
         );
     }
 

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -36,6 +36,14 @@ pub struct AssetSignature {
     pub(crate) signature: String,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct EdgeAppCreationResponse {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
 impl EdgeAppCommand {
     pub fn new(authentication: Authentication) -> Self {
         Self { authentication }
@@ -59,14 +67,6 @@ impl EdgeAppCommand {
             "v4/edge-apps?select=id,name",
             &json!({ "name": name }),
         )?;
-
-        #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-        struct EdgeAppCreationResponse {
-            #[serde(default)]
-            pub id: String,
-            #[serde(default)]
-            pub name: String,
-        }
 
         let json_response = serde_json::from_value::<Vec<EdgeAppCreationResponse>>(response)?;
         let app_id = json_response[0].id.clone();
@@ -120,14 +120,6 @@ impl EdgeAppCommand {
             "v4/edge-apps?select=id,name",
             &json!({ "name": name }),
         )?;
-
-        #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-        struct EdgeAppCreationResponse {
-            #[serde(default)]
-            pub id: String,
-            #[serde(default)]
-            pub name: String,
-        }
 
         let json_response = serde_json::from_value::<Vec<EdgeAppCreationResponse>>(response)?;
         let app_id = json_response[0].id.clone();
@@ -877,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn test_init_edge_app_should_create_edge_app_using_existing_files() {
+    fn test_create_in_place_edge_app_should_create_edge_app_using_existing_files() {
         let mock_server = MockServer::start();
         let post_mock = mock_server.mock(|when, then| {
             when.method(POST)
@@ -917,7 +909,7 @@ mod tests {
     }
 
     #[test]
-    fn test_init_edge_app_when_manifest_or_index_html_missed_should_return_error() {
+    fn test_create_in_place_edge_app_when_manifest_or_index_html_missed_should_return_error() {
         let command = EdgeAppCommand::new(Authentication::new_with_config(
             Config::new("http://localhost".to_string()),
             "token",
@@ -956,7 +948,7 @@ mod tests {
     }
 
     #[test]
-    fn test_init_edge_app_when_manifest_has_non_empty_app_id_should_return_error() {
+    fn test_create_in_place_edge_app_when_manifest_has_non_empty_app_id_should_return_error() {
         let command = EdgeAppCommand::new(Authentication::new_with_config(
             Config::new("http://localhost".to_string()),
             "token",

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -112,7 +112,7 @@ impl EdgeAppCommand {
         let mut manifest: EdgeAppManifest = serde_yaml::from_str(&data)?;
 
         if !manifest.app_id.is_empty() {
-            return Err(CommandError::FileSystemError("app_id in screenly.yml should not be set".to_string()));
+            return Err(CommandError::InitializationError("The operation can only proceed when 'app_id' is not set in the 'screenly.yml' configuration file".to_string()));
         }
 
         let response = commands::post(
@@ -976,7 +976,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Filesystem error: app_id in screenly.yml should not be set"
+            "Initialization Failed: The operation can only proceed when 'app_id' is not set in the 'screenly.yml' configuration file"
         );
     }
 

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -111,10 +111,8 @@ impl EdgeAppCommand {
         let data = fs::read_to_string(path)?;
         let mut manifest: EdgeAppManifest = serde_yaml::from_str(&data)?;
 
-        if manifest.app_id != "" {
-            return Err(CommandError::FileSystemError(format!(
-                "app_id in screenly.yml must be empty"
-            )));
+        if !manifest.app_id.is_empty() {
+            return Err(CommandError::FileSystemError("app_id in screenly.yml must be empty".to_string()));
         }
 
         let response = commands::post(

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -95,6 +95,54 @@ impl EdgeAppCommand {
         Ok(())
     }
 
+    pub fn init(&self, name: &str, path: &Path) -> Result<(), CommandError> {
+        let parent_dir_path = path.parent().ok_or(CommandError::FileSystemError(
+            "Can not obtain edge app root directory.".to_owned(),
+        ))?;
+        let index_html_path = parent_dir_path.join("index.html");
+
+        if !(Path::new(&path).exists() && Path::new(&index_html_path).exists()) {
+            return Err(CommandError::FileSystemError(format!(
+                "The directory {} should contain screenly.yml and index.html files",
+                parent_dir_path.display()
+            )));
+        }
+
+        let data = fs::read_to_string(path)?;
+        let mut manifest: EdgeAppManifest = serde_yaml::from_str(&data)?;
+
+        if manifest.app_id != "" {
+            return Err(CommandError::FileSystemError(format!(
+                "app_id in screenly.yml must be empty"
+            )));
+        }
+
+        let response = commands::post(
+            &self.authentication,
+            "v4/edge-apps?select=id,name",
+            &json!({ "name": name }),
+        )?;
+
+        #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+        struct EdgeAppCreationResponse {
+            #[serde(default)]
+            pub id: String,
+            #[serde(default)]
+            pub name: String,
+        }
+
+        let json_response = serde_json::from_value::<Vec<EdgeAppCreationResponse>>(response)?;
+        let app_id = json_response[0].id.clone();
+        if app_id.is_empty() {
+            return Err(CommandError::MissingField);
+        }
+
+        manifest.app_id = app_id;
+        EdgeAppManifest::save_to_file(&manifest, path)?;
+
+        Ok(())
+    }
+
     pub fn list(&self) -> Result<EdgeApps, CommandError> {
         Ok(EdgeApps::new(commands::get(
             &self.authentication,
@@ -783,7 +831,7 @@ mod tests {
                 type_: "string".to_string(),
                 default_value: "stranger".to_string(),
                 optional: true,
-                help_text: "An example of a setting that is used in index.html".to_string()
+                help_text: "An example of a setting that is used in index.html".to_string(),
             }]
         );
 
@@ -828,6 +876,118 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("already contains a screenly.yml or index.html file"));
+    }
+
+    #[test]
+    fn test_init_edge_app_should_create_edge_app_using_existing_files() {
+        let mock_server = MockServer::start();
+        let post_mock = mock_server.mock(|when, then| {
+            when.method(POST)
+                .path("/v4/edge-apps")
+                .header("Authorization", "Token token")
+                .json_body(json!({
+                    "name": "Best app ever"
+                }));
+            then.status(201)
+                .json_body(json!([{"id": "test-id", "name": "Best app ever"}]));
+        });
+
+        let config = Config::new(mock_server.base_url());
+        let authentication = Authentication::new_with_config(config, "token");
+        let command = EdgeAppCommand::new(authentication);
+
+        // Prepare screenly.yml and index.html
+        let tmp_dir = tempdir().unwrap();
+        File::create(tmp_dir.path().join("index.html")).unwrap();
+        EdgeAppManifest::save_to_file(
+            &EdgeAppManifest { ..Default::default() },
+            tmp_dir.path().join("screenly.yml").as_path(),
+        ).unwrap();
+
+        let result = command.init(
+            "Best app ever",
+            tmp_dir.path().join("screenly.yml").as_path(),
+        );
+
+        post_mock.assert();
+
+        let data = fs::read_to_string(tmp_dir.path().join("screenly.yml")).unwrap();
+        let manifest: EdgeAppManifest = serde_yaml::from_str(&data).unwrap();
+        assert_eq!(manifest.app_id, "test-id");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_init_edge_app_when_manifest_or_index_html_missed_should_return_error() {
+        let command = EdgeAppCommand::new(Authentication::new_with_config(
+            Config::new("http://localhost".to_string()),
+            "token",
+        ));
+
+        let tmp_dir = tempdir().unwrap();
+        File::create(tmp_dir.path().join("screenly.yml")).unwrap();
+
+        let result = command.init(
+            "Best app ever",
+            tmp_dir.path().join("screenly.yml").as_path(),
+        );
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("should contain screenly.yml and index.html files")
+        );
+
+        fs::remove_file(tmp_dir.path().join("screenly.yml")).unwrap();
+
+        File::create(tmp_dir.path().join("index.html")).unwrap();
+
+        let result = command.init(
+            "Best app ever",
+            tmp_dir.path().join("screenly.yml").as_path(),
+        );
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("should contain screenly.yml and index.html files")
+        );
+    }
+
+    #[test]
+    fn test_init_edge_app_when_manifest_has_non_empty_app_id_should_return_error() {
+        let command = EdgeAppCommand::new(Authentication::new_with_config(
+            Config::new("http://localhost".to_string()),
+            "token",
+        ));
+
+        let tmp_dir = tempdir().unwrap();
+
+        File::create(tmp_dir.path().join("index.html")).unwrap();
+
+        let manifest = EdgeAppManifest {
+            app_id: "non-empty".to_string(),
+            ..Default::default()
+        };
+
+        EdgeAppManifest::save_to_file(
+            &manifest,
+            tmp_dir.path().join("screenly.yml").as_path(),
+        ).unwrap();
+
+        let result = command.init(
+            "Best app ever",
+            tmp_dir.path().join("screenly.yml").as_path(),
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Filesystem error: app_id in screenly.yml must be empty"
+        );
     }
 
     #[test]

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -49,7 +49,7 @@ impl EdgeAppCommand {
 
         if Path::new(&path).exists() || Path::new(&index_html_path).exists() {
             return Err(CommandError::FileSystemError(format!(
-                "The directory {} already contains a screenly.yml or index.html file",
+                "The directory {} already contains a screenly.yml or index.html file. Use --in-place if you want to create an Edge App in this directory",
                 parent_dir_path.display()
             )));
         }
@@ -95,7 +95,7 @@ impl EdgeAppCommand {
         Ok(())
     }
 
-    pub fn init(&self, name: &str, path: &Path) -> Result<(), CommandError> {
+    pub fn create_in_place(&self, name: &str, path: &Path) -> Result<(), CommandError> {
         let parent_dir_path = path.parent().ok_or(CommandError::FileSystemError(
             "Can not obtain edge app root directory.".to_owned(),
         ))?;
@@ -858,7 +858,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("already contains a screenly.yml or index.html file"));
+            .contains("already contains a screenly.yml or index.html file. Use --in-place if you want to create an Edge App in this directory"));
 
         fs::remove_file(tmp_dir.path().join("screenly.yml")).unwrap();
 
@@ -873,7 +873,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("already contains a screenly.yml or index.html file"));
+            .contains("already contains a screenly.yml or index.html file. Use --in-place if you want to create an Edge App in this directory"));
     }
 
     #[test]
@@ -902,7 +902,7 @@ mod tests {
             tmp_dir.path().join("screenly.yml").as_path(),
         ).unwrap();
 
-        let result = command.init(
+        let result = command.create_in_place(
             "Best app ever",
             tmp_dir.path().join("screenly.yml").as_path(),
         );
@@ -926,7 +926,7 @@ mod tests {
         let tmp_dir = tempdir().unwrap();
         File::create(tmp_dir.path().join("screenly.yml")).unwrap();
 
-        let result = command.init(
+        let result = command.create_in_place(
             "Best app ever",
             tmp_dir.path().join("screenly.yml").as_path(),
         );
@@ -942,7 +942,7 @@ mod tests {
 
         File::create(tmp_dir.path().join("index.html")).unwrap();
 
-        let result = command.init(
+        let result = command.create_in_place(
             "Best app ever",
             tmp_dir.path().join("screenly.yml").as_path(),
         );
@@ -976,7 +976,7 @@ mod tests {
             tmp_dir.path().join("screenly.yml").as_path(),
         ).unwrap();
 
-        let result = command.init(
+        let result = command.create_in_place(
             "Best app ever",
             tmp_dir.path().join("screenly.yml").as_path(),
         );

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -101,6 +101,8 @@ pub enum CommandError {
     FileSystemError(String),
     #[error("Asset processing timeout")]
     AssetProcessingTimeout,
+    #[error("Initialization Failed: {0}")]
+    InitializationError(String),
 }
 
 pub fn get(


### PR DESCRIPTION
## What does this PR do?
Added a new option for create command: `screenly edge-app create --in-place`.

This option allows creating edge-app using an existing edge-app directory (see Playground edge-apps for an example).

## GitHub issue or Phabricator ticket number?
@vpetersson please add a ticket number. I can't find it.

## How has this been tested?
Manually and unit tests.

## Checklist before merging

- [x] If have added tests.
- [x] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
