### PR TITLE
Fix: filter out edge-app-files from assets list command

### DIFF
--- a/src/commands/asset.rs
+++ b/src/commands/asset.rs
@@ -23,7 +23,7 @@ impl AssetCommand {
     pub fn list(&self) -> anyhow::Result<Assets, CommandError> {
         Ok(Assets::new(commands::get(
             &self.authentication,
-            "v4/assets",
+            "v4/assets?type=in.('appweb','audio','edge-app','image','video','web')",
         )?))
     }
 
@@ -214,6 +214,7 @@ mod tests {
         mock_server.mock(|when, then| {
             when.method(GET)
                 .path("/v4/assets")
+                .query_param("type", "in.('appweb','audio','edge-app','image','video','web')")
                 .header("Authorization", "Token token")
                 .header(
                     "user-agent",

--- a/src/commands/asset.rs
+++ b/src/commands/asset.rs
@@ -23,7 +23,7 @@ impl AssetCommand {
     pub fn list(&self) -> anyhow::Result<Assets, CommandError> {
         Ok(Assets::new(commands::get(
             &self.authentication,
-            "v4/assets?type=in.('audio','edge-app','image','video','web')",
+            "v4/assets?type=neq.file-edge-app",
         )?))
     }
 
@@ -214,7 +214,7 @@ mod tests {
         mock_server.mock(|when, then| {
             when.method(GET)
                 .path("/v4/assets")
-                .query_param("type", "in.('audio','edge-app','image','video','web')")
+                .query_param("type", "neq.file-edge-app")
                 .header("Authorization", "Token token")
                 .header(
                     "user-agent",

--- a/src/commands/asset.rs
+++ b/src/commands/asset.rs
@@ -23,7 +23,7 @@ impl AssetCommand {
     pub fn list(&self) -> anyhow::Result<Assets, CommandError> {
         Ok(Assets::new(commands::get(
             &self.authentication,
-            "v4/assets?type=in.('appweb','audio','edge-app','image','video','web')",
+            "v4/assets?type=in.('audio','edge-app','image','video','web')",
         )?))
     }
 
@@ -214,7 +214,7 @@ mod tests {
         mock_server.mock(|when, then| {
             when.method(GET)
                 .path("/v4/assets")
-                .query_param("type", "in.('appweb','audio','edge-app','image','video','web')")
+                .query_param("type", "in.('audio','edge-app','image','video','web')")
                 .header("Authorization", "Token token")
                 .header(
                     "user-agent",


### PR DESCRIPTION
## What does this PR do?
filter out edge-app-files from assets list command. Just the same way as we do it in web-console.

## GitHub issue or Phabricator ticket number?
https://phorge.wireload.net/T7310

## How has this been tested?
Manually

## Checklist before merging

- [ ] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
