### PR TITLE
Adds: delete edge-app command - same as screen deletion

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -275,7 +275,7 @@ pub enum AssetCommands {
 pub enum EdgeAppCommands {
     /// Creates Edge App in the store.
     Create {
-        /// Edge app name
+        /// Edge App name
         #[arg(short, long)]
         name: String,
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
@@ -286,7 +286,7 @@ pub enum EdgeAppCommands {
         in_place: Option<bool>,
     },
 
-    /// Lists your edge apps.
+    /// Lists your Edge Apps.
     List {
         /// Enables JSON output.
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
@@ -336,23 +336,23 @@ pub enum EdgeAppCommands {
     #[command(subcommand)]
     Secret(EdgeAppSecretsCommands),
 
-    /// Uploads assets and settings of the edge app.
+    /// Uploads assets and settings of the Edge App.
     Upload {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         #[arg(short, long)]
         path: Option<String>,
 
-        /// Edge app id. If not specified CLI will use the id from the manifest.
+        /// Edge App id. If not specified CLI will use the id from the manifest.
         #[arg(short, long)]
         app_id: Option<String>,
     },
-    /// Deletes an edge app. This cannot be undone.
+    /// Deletes an Edge App. This cannot be undone.
     Delete {
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
         #[arg(short, long)]
         path: Option<String>,
 
-        /// Edge app id. If not specified CLI will use the id from the manifest.
+        /// Edge App id. If not specified CLI will use the id from the manifest.
         #[arg(short, long)]
         app_id: Option<String>,
     },
@@ -1003,8 +1003,8 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             let actual_app_id = get_actual_app_id(app_id, path);
             match edge_app_command.get_app_name(&actual_app_id) {
                 Ok(name) => {
-                    info!("You are about to delete the app named \"{}\".  This operation cannot be reversed.", name);
-                    info!("Enter the app name to confirm the app deletion: ");
+                    info!("You are about to delete the Edge App named \"{}\".  This operation cannot be reversed.", name);
+                    info!("Enter the Edge App name to confirm the app deletion: ");
                     if name != get_user_input() {
                         error!("The name you entered is incorrect. Aborting.");
                         std::process::exit(1);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1019,6 +1019,20 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             match edge_app_command.delete_app(&actual_app_id) {
                 Ok(()) => {
                     info!("App deleted successfully.");
+                    // If the user didn't specify an app id, we need to clear it from the manifest
+                    if app_id.is_none() {
+                        match edge_app_command
+                            .clear_app_id(transform_edge_app_path_to_manifest(path).as_path())
+                        {
+                            Ok(()) => {
+                                info!("App id cleared from manifest.");
+                            }
+                            Err(e) => {
+                                error!("Error occurred while clearing manifest: {}", e);
+                                std::process::exit(1);
+                            }
+                        }
+                    }
                     std::process::exit(0);
                 }
                 Err(e) => {
@@ -1026,7 +1040,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     std::process::exit(1);
                 }
             }
-        },
+        }
         EdgeAppCommands::Update { path, app_id, name } => {
             let actual_app_id = get_actual_app_id(app_id, path);
             match edge_app_command.update_name(&actual_app_id, name) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1091,9 +1091,15 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     std::process::exit(1);
                 }
             }
-        },
+        }
         EdgeAppCommands::Rename { path, app_id, name } => {
-            let actual_app_id = get_actual_app_id(app_id, path);
+            let actual_app_id = match get_actual_app_id(app_id, path) {
+                Ok(id) => id,
+                Err(e) => {
+                    error!("Error calling delete Edge App: {}", e);
+                    std::process::exit(1);
+                }
+            };
             match edge_app_command.update_name(&actual_app_id, name) {
                 Ok(()) => {
                     println!("Edge app successfully updated.");

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -78,7 +78,7 @@ impl EdgeAppCommand {
         }
 
         let manifest = EdgeAppManifest {
-            app_id,
+            app_id: Some(app_id),
             settings: vec![Setting {
                 title: "greeting".to_string(),
                 type_: "string".to_string(),
@@ -114,7 +114,7 @@ impl EdgeAppCommand {
         let data = fs::read_to_string(path)?;
         let mut manifest: EdgeAppManifest = serde_yaml::from_str(&data)?;
 
-        if !manifest.app_id.is_empty() {
+        if manifest.app_id.is_some() {
             return Err(CommandError::InitializationError("The operation can only proceed when 'app_id' is not set in the 'screenly.yml' configuration file".to_string()));
         }
 
@@ -130,7 +130,7 @@ impl EdgeAppCommand {
             return Err(CommandError::MissingField);
         }
 
-        manifest.app_id = app_id;
+        manifest.app_id = Some(app_id);
         EdgeAppManifest::save_to_file(&manifest, path)?;
 
         Ok(())
@@ -324,17 +324,21 @@ impl EdgeAppCommand {
 
         // override app_id if user passed it
         if let Some(id) = app_id {
-            manifest.app_id = id;
+            manifest.app_id = Some(id);
         }
+        let actual_app_id = match manifest.app_id {
+            Some(ref id) => id,
+            None => return Err(CommandError::MissingField),
+        };
 
         let edge_app_dir = path.parent().ok_or(CommandError::MissingField)?;
 
         let local_files = collect_paths_for_upload(edge_app_dir)?;
         ensure_edge_app_has_all_necessary_files(&local_files)?;
 
-        let revision = self.get_latest_revision(&manifest.app_id).unwrap_or(0);
+        let revision = self.get_latest_revision(actual_app_id).unwrap_or(0);
 
-        let remote_files = self.get_version_asset_signatures(&manifest.app_id, revision)?;
+        let remote_files = self.get_version_asset_signatures(actual_app_id, revision)?;
         let changed_files = detect_changed_files(&local_files, &remote_files)?;
         debug!("Changed files: {:?}", &changed_files);
 
@@ -342,16 +346,16 @@ impl EdgeAppCommand {
             &self.authentication,
             &format!(
                 "v4/edge-apps/settings?select=type,default_value,optional,title,help_text&app_id=eq.{}&order=title.asc",
-                manifest.app_id
+                actual_app_id,
             ),
         )?)?;
 
         let changed_settings = detect_changed_settings(&manifest, &remote_settings)?;
-        self.upload_changed_settings(&manifest, &changed_settings)?;
+        self.upload_changed_settings(actual_app_id.clone(), &changed_settings)?;
 
         let file_tree = generate_file_tree(&local_files, edge_app_dir);
 
-        let old_file_tree = self.get_file_tree(&manifest.app_id, revision);
+        let old_file_tree = self.get_file_tree(actual_app_id, revision);
 
         let file_tree_changed = match old_file_tree {
             Ok(tree) => file_tree != tree,
@@ -369,15 +373,15 @@ impl EdgeAppCommand {
         let revision =
             self.create_version(&manifest, generate_file_tree(&local_files, edge_app_dir))?;
 
-        self.upload_changed_files(edge_app_dir, &manifest.app_id, revision, &changed_files)?;
+        self.upload_changed_files(edge_app_dir, actual_app_id, revision, &changed_files)?;
         debug!("Files uploaded");
 
-        self.ensure_assets_processing_finished(&manifest.app_id, revision)?;
+        self.ensure_assets_processing_finished(actual_app_id, revision)?;
         // now we freeze it by publishing it
-        self.publish(&manifest.app_id, revision)?;
+        self.publish(actual_app_id, revision)?;
         debug!("Edge app published.");
 
-        self.get_or_create_installation(&manifest.app_id)?;
+        self.get_or_create_installation(actual_app_id)?;
 
         Ok(revision)
     }
@@ -458,7 +462,7 @@ impl EdgeAppCommand {
         let data = fs::read_to_string(path)?;
         let mut manifest: EdgeAppManifest = serde_yaml::from_str(&data)?;
 
-        manifest.app_id = "".to_owned();
+        manifest.app_id = None;
         EdgeAppManifest::save_to_file(&manifest, PathBuf::from(path).as_path())?;
 
         Ok(())
@@ -722,14 +726,14 @@ impl EdgeAppCommand {
 
     fn upload_changed_settings(
         &self,
-        manifest: &EdgeAppManifest,
+        app_id: String,
         changed_settings: &SettingChanges,
     ) -> Result<(), CommandError> {
         for setting in &changed_settings.creates {
-            self.create_setting(manifest, setting)?;
+            self.create_setting(app_id.clone(), setting)?;
         }
         for setting in &changed_settings.updates {
-            self.update_setting(manifest, setting)?;
+            self.update_setting(app_id.clone(), setting)?;
         }
         Ok(())
     }
@@ -760,14 +764,10 @@ impl EdgeAppCommand {
         Ok(())
     }
 
-    fn create_setting(
-        &self,
-        manifest: &EdgeAppManifest,
-        setting: &Setting,
-    ) -> Result<(), CommandError> {
+    fn create_setting(&self, app_id: String, setting: &Setting) -> Result<(), CommandError> {
         let value = serde_json::to_value(setting)?;
         let mut payload = serde_json::from_value::<HashMap<String, serde_json::Value>>(value)?;
-        payload.insert("app_id".to_owned(), json!(manifest.app_id));
+        payload.insert("app_id".to_owned(), json!(app_id));
 
         debug!("Creating setting: {:?}", &payload);
 
@@ -775,7 +775,7 @@ impl EdgeAppCommand {
         if response.is_err() {
             let c = commands::get(
                 &self.authentication,
-                &format!("v4/edge-apps/settings?app_id=eq.{}", manifest.app_id),
+                &format!("v4/edge-apps/settings?app_id=eq.{}", app_id),
             )?;
             debug!("Existing settings: {:?}", c);
             return Err(CommandError::NoChangesToUpload("".to_owned()));
@@ -784,11 +784,7 @@ impl EdgeAppCommand {
         Ok(())
     }
 
-    fn update_setting(
-        &self,
-        manifest: &EdgeAppManifest,
-        setting: &Setting,
-    ) -> Result<(), CommandError> {
+    fn update_setting(&self, app_id: String, setting: &Setting) -> Result<(), CommandError> {
         let value = serde_json::to_value(setting)?;
         let payload = serde_json::from_value::<HashMap<String, serde_json::Value>>(value)?;
 
@@ -798,7 +794,7 @@ impl EdgeAppCommand {
             &self.authentication,
             &format!(
                 "v4/edge-apps/settings?app_id=eq.{id}&title=eq.{title}",
-                id = manifest.app_id,
+                id = app_id,
                 title = setting.title
             ),
             &payload,
@@ -977,7 +973,7 @@ mod tests {
 
         let data = fs::read_to_string(tmp_dir.path().join("screenly.yml")).unwrap();
         let manifest: EdgeAppManifest = serde_yaml::from_str(&data).unwrap();
-        assert_eq!(manifest.app_id, "test-id");
+        assert_eq!(manifest.app_id, Some("test-id".to_owned()));
         assert_eq!(
             manifest.settings,
             vec![Setting {
@@ -1070,7 +1066,7 @@ mod tests {
 
         let data = fs::read_to_string(tmp_dir.path().join("screenly.yml")).unwrap();
         let manifest: EdgeAppManifest = serde_yaml::from_str(&data).unwrap();
-        assert_eq!(manifest.app_id, "test-id");
+        assert_eq!(manifest.app_id, Some("test-id".to_owned()));
 
         assert!(result.is_ok());
     }
@@ -1124,7 +1120,7 @@ mod tests {
         File::create(tmp_dir.path().join("index.html")).unwrap();
 
         let manifest = EdgeAppManifest {
-            app_id: "non-empty".to_string(),
+            app_id: Some("non-empty".to_string()),
             ..Default::default()
         };
 
@@ -1292,7 +1288,7 @@ mod tests {
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -1301,7 +1297,7 @@ mod tests {
             settings: vec![],
         };
 
-        let result = command.list_settings(&manifest.app_id);
+        let result = command.list_settings(&manifest.app_id.unwrap());
 
         installation_mock.assert();
         installation_mock_create.assert();
@@ -1417,7 +1413,7 @@ mod tests {
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -1426,7 +1422,7 @@ mod tests {
             settings: vec![],
         };
 
-        let result = command.set_setting(&manifest.app_id, "best_setting", "best_value");
+        let result = command.set_setting(&manifest.app_id.unwrap(), "best_setting", "best_value");
         installation_mock.assert();
         installation_mock_create.assert();
         setting_values_mock_get.assert();
@@ -1499,7 +1495,7 @@ mod tests {
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -1508,7 +1504,7 @@ mod tests {
             settings: vec![],
         };
 
-        let result = command.set_setting(&manifest.app_id, "best_setting", "best_value1");
+        let result = command.set_setting(&manifest.app_id.unwrap(), "best_setting", "best_value1");
         installation_mock.assert();
         setting_values_mock_get.assert();
         setting_values_mock_patch.assert();
@@ -1579,7 +1575,7 @@ mod tests {
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -1588,8 +1584,11 @@ mod tests {
             settings: vec![],
         };
 
-        let result =
-            command.set_secret(&manifest.app_id, "best_secret_setting", "best_secret_value");
+        let result = command.set_secret(
+            &manifest.app_id.unwrap(),
+            "best_secret_setting",
+            "best_secret_value",
+        );
         installation_mock.assert();
         installation_mock_create.assert();
         secrets_values_mock_post.assert();
@@ -1600,7 +1599,7 @@ mod tests {
     #[test]
     fn test_upload_should_send_correct_requests() {
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -1936,7 +1935,7 @@ mod tests {
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -1945,7 +1944,7 @@ mod tests {
             settings: vec![],
         };
 
-        let result = command.promote_version(&manifest.app_id, &7, &"public".to_string());
+        let result = command.promote_version(&manifest.app_id.unwrap(), &7, &"public".to_string());
 
         installation_mock.assert();
         installation_mock_create.assert();
@@ -1962,7 +1961,7 @@ mod tests {
 
         // The EdgeAppManifest structure from your example
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -2017,7 +2016,7 @@ settings:
         let file_path = dir.path().join("test_manifest_with_varied_settings.yml");
 
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -2057,7 +2056,7 @@ settings:
     #[test]
     fn test_ensure_assets_processing_finished_when_processing_failed_should_return_error() {
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -2163,7 +2162,7 @@ settings:
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -2172,7 +2171,7 @@ settings:
             settings: vec![],
         };
 
-        let result = command.list_secrets(&manifest.app_id);
+        let result = command.list_secrets(&manifest.app_id.unwrap());
 
         secrets_mock.assert();
 
@@ -2259,7 +2258,7 @@ settings:
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -2268,7 +2267,7 @@ settings:
             settings: vec![],
         };
 
-        let result = command.promote_version(&manifest.app_id, &7, &"public".to_string());
+        let result = command.promote_version(&manifest.app_id.unwrap(), &7, &"public".to_string());
 
         installation_mock.assert();
         installation_mock_create.assert();
@@ -2307,7 +2306,7 @@ settings:
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -2316,7 +2315,7 @@ settings:
             settings: vec![],
         };
 
-        let result = command.update_name(&manifest.app_id, "New name");
+        let result = command.update_name(&manifest.app_id.unwrap(), "New name");
         update_name_mock.assert();
         debug!("result: {:?}", result);
         assert!(result.is_ok());
@@ -2348,7 +2347,7 @@ settings:
         let mock_server = MockServer::start();
 
         let manifest = EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),
@@ -2371,7 +2370,7 @@ settings:
         let new_manifest: EdgeAppManifest = serde_yaml::from_str(&data).unwrap();
 
         let expected_manifest = EdgeAppManifest {
-            app_id: "".to_string(),
+            app_id: None,
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -174,7 +174,7 @@ mod tests {
 
     fn create_manifest() -> EdgeAppManifest {
         EdgeAppManifest {
-            app_id: "01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string(),
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -111,6 +111,8 @@ pub enum CommandError {
     AssetProcessingError(String),
     #[error("Warning: these secrets are undefined: {0}.")]
     UndefinedSecrets(String),
+    #[error("App id is required. Either in manifest or with --app-id .")]
+    MissingAppId,
 }
 
 pub fn get(
@@ -214,7 +216,8 @@ pub fn patch<T: Serialize + ?Sized>(
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EdgeAppManifest {
-    pub app_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
     pub user_version: String,
     pub description: String,
     pub icon: String,
@@ -649,7 +652,7 @@ mod tests {
         let file_path = dir.path().join("test.yaml");
 
         let manifest = EdgeAppManifest {
-            app_id: "test_app".to_string(),
+            app_id: Some("test_app".to_string()),
             settings: vec![Setting {
                 title: "username".to_string(),
                 type_: "string".to_string(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -166,10 +166,12 @@ pub fn post<T: Serialize + ?Sized>(
 pub fn delete(authentication: &Authentication, endpoint: &str) -> anyhow::Result<(), CommandError> {
     let url = format!("{}/{}", &authentication.config.url, endpoint);
     let response = authentication.build_client()?.delete(url).send()?;
-    if ![StatusCode::OK, StatusCode::NO_CONTENT].contains(&response.status()) {
-        return Err(CommandError::WrongResponseStatus(
-            response.status().as_u16(),
-        ));
+
+    let status = response.status();
+
+    if ![StatusCode::OK, StatusCode::NO_CONTENT].contains(&status) {
+        debug!("Response: {:?}", &response.text()?);
+        return Err(CommandError::WrongResponseStatus(status.as_u16()));
     }
     Ok(())
 }


### PR DESCRIPTION
Refs https://phorge.wireload.net/T7415

Same as screen deletion - ask for name promt before deletion

`screenly edge-app delete`

Also updated manifest to have app_id optional -> `Option<String>`