### PR TITLE
Adds: check that revision exist before promote call

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -113,6 +113,8 @@ pub enum CommandError {
     UndefinedSecrets(String),
     #[error("App id is required. Either in manifest or with --app-id .")]
     MissingAppId,
+    #[error("Edge App Revision {0} not found")]
+    RevisionNotFound(String),
 }
 
 pub fn get(


### PR DESCRIPTION
It was not informative 401 error when trying to promote revision, that doesn't exist.

Now added proper get request to versions and fails if version/revision doesn't exist
`Failed to promote edge app version: Edge App Revision 4 not found.`