### PR TITLE
Promote latest

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -376,7 +376,7 @@ pub enum EdgeAppVersionCommands {
     Promote {
         /// Edge app revision to promote.
         #[arg(short, long)]
-        revision: u32,
+        revision: Option<u32>,
         /// Channel to promote to. If not specified CLI will use stable channel.
         #[arg(short, long, default_value = "stable")]
         channel: String,
@@ -385,7 +385,7 @@ pub enum EdgeAppVersionCommands {
         #[arg(short, long)]
         app_id: Option<String>,
 
-        #[arg(long,  action = clap::ArgAction::SetTrue, conflicts_with = "revision")]
+        #[arg(long,  action = clap::ArgAction::SetTrue, conflicts_with = "revision", default_value="false")]
         latest: bool,
 
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
@@ -971,7 +971,15 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                         }
                     }
                 } else {
-                    *revision
+                    match revision {
+                        Some(rev) => *rev,
+                        None => {
+                            println!(
+                                "You must either specify a revision or use the --latest flag."
+                            );
+                            std::process::exit(1);
+                        }
+                    }
                 };
 
                 match edge_app_command.promote_version(&actual_app_id, revision, channel) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -385,7 +385,7 @@ pub enum EdgeAppVersionCommands {
         #[arg(short, long)]
         app_id: Option<String>,
 
-        #[arg(long, action = "clap::ArgAction::SetTrue", conflicts_with = "revision")]
+        #[arg(long,  action = clap::ArgAction::SetTrue, conflicts_with = "revision")]
         latest: bool,
 
         /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
@@ -962,7 +962,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     }
                 };
 
-                let revision = if latest {
+                let revision = if *latest {
                     match edge_app_command.get_latest_revision(&actual_app_id) {
                         Ok(rev) => rev,
                         Err(e) => {

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -389,7 +389,7 @@ impl EdgeAppCommand {
     pub fn promote_version(
         &self,
         app_id: &str,
-        revision: &u32,
+        revision: u32,
         channel: &String,
     ) -> Result<(), CommandError> {
         let secrets = self.get_undefined_secrets(app_id)?;
@@ -436,7 +436,7 @@ impl EdgeAppCommand {
         if channels.is_empty() {
             return Err(CommandError::MissingField);
         }
-        if &channels[0].channel != channel || &channels[0].app_revision != revision {
+        if &channels[0].channel != channel || channels[0].app_revision != revision {
             return Err(CommandError::MissingField);
         }
 
@@ -572,7 +572,7 @@ impl EdgeAppCommand {
         Err(CommandError::MissingField)
     }
 
-    fn get_latest_revision(&self, app_id: &str) -> Result<u32, CommandError> {
+    pub fn get_latest_revision(&self, app_id: &str) -> Result<u32, CommandError> {
         let response = commands::get(
             &self.authentication,
             &format!(
@@ -2004,7 +2004,7 @@ mod tests {
             settings: vec![],
         };
 
-        let result = command.promote_version(&manifest.app_id.unwrap(), &7, &"public".to_string());
+        let result = command.promote_version(&manifest.app_id.unwrap(), 7, &"public".to_string());
 
         get_version_mock.assert();
         installation_mock.assert();
@@ -2328,7 +2328,7 @@ settings:
             settings: vec![],
         };
 
-        let result = command.promote_version(&manifest.app_id.unwrap(), &7, &"public".to_string());
+        let result = command.promote_version(&manifest.app_id.unwrap(), 7, &"public".to_string());
 
         installation_mock.assert();
         installation_mock_create.assert();
@@ -2419,7 +2419,7 @@ settings:
             settings: vec![],
         };
 
-        let result = command.promote_version(&manifest.app_id.unwrap(), &7, &"public".to_string());
+        let result = command.promote_version(&manifest.app_id.unwrap(), 7, &"public".to_string());
 
         get_version_mock.assert();
         installation_mock.assert();


### PR DESCRIPTION
## What does this PR do?
Adds --latest for promote. That flag can be used to promote the latest promoted revision.

## GitHub issue or Phabricator ticket number?

## How has this been tested?
Manually as we don't have tests for interaction with the app. get_latest_revision already had tests.
## Checklist before merging

- [ ] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
