### PR TITLE
Revert "Custom deserializers for empty string and settings type"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,6 @@ serde_yaml = "0.9.17"
 sha1 = "0.10.5"
 sha2 = "0.10.7"
 simple_logger = { version = "4.0.0", features= ["colors"]}
-strum = "0.25"
-strum_macros = "0.25"
 term = "0.7.0"
 thiserror = "1.0.37"
 sentry = "0.31.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -356,12 +356,6 @@ pub enum EdgeAppCommands {
         #[arg(short, long)]
         app_id: Option<String>,
     },
-    /// Validates Edge App manifest file
-    Validate {
-        /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
-        #[arg(short, long)]
-        path: Option<String>,
-    },
 }
 
 #[derive(Subcommand, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -517,16 +511,13 @@ fn get_actual_app_id(
     path: &Option<String>,
 ) -> Result<String, CommandError> {
     match app_id {
-        Some(id) if id.is_empty() => {
-            Err(CommandError::EmptyAppId)
-        },
         Some(id) => Ok(id.clone()),
         None => {
             let manifest =
                 EdgeAppManifest::new(transform_edge_app_path_to_manifest(path).as_path()).unwrap();
             match manifest.app_id {
-                Some(id) if !id.is_empty() => Ok(id.clone()),
-                _ =>  {
+                Some(id) => Ok(id),
+                None => {
                     error!("Edge app id is not specified. Please specify it using --app-id option or add it to the manifest.");
                     Err(CommandError::MissingAppId)
                 }
@@ -686,7 +677,7 @@ pub fn handle_cli_playlist_command(command: &PlaylistCommands) {
                     println!("{}", pretty_playlist_file);
                 }
                 Err(e) => {
-                    eprintln!("Error occurred when getting playlist: {e:?}")
+                    println!("Error occurred when getting playlist: {e:?}")
                 }
             }
         }
@@ -695,7 +686,7 @@ pub fn handle_cli_playlist_command(command: &PlaylistCommands) {
                 println!("Playlist deleted successfully.");
             }
             Err(e) => {
-                eprintln!("Error occurred when deleting playlist: {e:?}")
+                println!("Error occurred when deleting playlist: {e:?}")
             }
         },
         PlaylistCommands::Append {
@@ -741,7 +732,7 @@ pub fn handle_cli_playlist_command(command: &PlaylistCommands) {
                     println!("Playlist updated successfully.");
                 }
                 Err(e) => {
-                    eprintln!("Error occurred when updating playlist: {e:?}")
+                    println!("Error occurred when updating playlist: {e:?}")
                 }
             }
         }
@@ -916,7 +907,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     println!("Edge app successfully created.");
                 }
                 Err(e) => {
-                    eprintln!("Failed to publish edge app manifest: {e}.");
+                    println!("Failed to publish edge app manifest: {e}.");
                     std::process::exit(1);
                 }
             }
@@ -937,7 +928,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     );
                 }
                 Err(e) => {
-                    eprintln!("Failed to upload edge app: {e}.");
+                    println!("Failed to upload edge app: {e}.");
                     std::process::exit(1);
                 }
             }
@@ -996,7 +987,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                         println!("Edge app version successfully promoted.");
                     }
                     Err(e) => {
-                        eprintln!("Failed to promote edge app version: {e}.");
+                        println!("Failed to promote edge app version: {e}.");
                         std::process::exit(1);
                     }
                 }
@@ -1034,7 +1025,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                         println!("Edge app setting successfully set.");
                     }
                     Err(e) => {
-                        eprintln!("Failed to set edge app setting: {}", e);
+                        println!("Failed to set edge app setting: {}", e);
                         std::process::exit(1);
                     }
                 }
@@ -1072,7 +1063,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                         println!("Edge app secret successfully set.");
                     }
                     Err(e) => {
-                        eprintln!("Failed to set edge app secret: {}", e);
+                        println!("Failed to set edge app secret: {}", e);
                         std::process::exit(1);
                     }
                 }
@@ -1139,7 +1130,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     println!("Edge app successfully updated.");
                 }
                 Err(e) => {
-                    eprintln!("Failed to update edge app: {e}.");
+                    println!("Failed to update edge app: {e}.");
                     std::process::exit(1);
                 }
             }
@@ -1155,7 +1146,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 None => env::current_dir().unwrap(),
             };
             if !path.join(MOCK_DATA_FILENAME).exists() {
-                eprintln!("Error: No mock-data exist. Please run \"screenly edge-app generate-mock-data\" and try again.");
+                println!("Error: No mock-data exist. Please run \"screenly edge-app generate-mock-data\" and try again.");
                 std::process::exit(1);
             }
 
@@ -1164,18 +1155,6 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
         EdgeAppCommands::GenerateMockData { path } => {
             let manifest_path = transform_edge_app_path_to_manifest(path);
             edge_app_command.generate_mock_data(&manifest_path).unwrap();
-        },
-        EdgeAppCommands::Validate { path } => {
-            let manifest_path = transform_edge_app_path_to_manifest(path);
-            match EdgeAppManifest::ensure_manifest_is_validated(&manifest_path) {
-                Ok(()) => {
-                    println!("Manifest file is valid.");
-                },
-                Err(e) => {
-                    eprintln!("{e}");
-                    std::process::exit(1);
-                }
-            }
         }
     }
 }

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -1,7 +1,7 @@
 use crate::authentication::Authentication;
 use crate::commands;
 use crate::commands::{
-    CommandError, EdgeAppManifest, EdgeAppSecrets, SettingType, EdgeAppSettings, EdgeAppVersions, EdgeApps,
+    CommandError, EdgeAppManifest, EdgeAppSecrets, EdgeAppSettings, EdgeAppVersions, EdgeApps,
     Setting,
 };
 use indicatif::ProgressBar;
@@ -81,7 +81,7 @@ impl EdgeAppCommand {
             app_id: Some(app_id),
             settings: vec![Setting {
                 title: "greeting".to_string(),
-                type_: SettingType::Secret,
+                type_: "string".to_string(),
                 default_value: "stranger".to_string(),
                 optional: true,
                 help_text: "An example of a setting that is used in index.html".to_string(),
@@ -324,14 +324,11 @@ impl EdgeAppCommand {
 
         // override app_id if user passed it
         if let Some(id) = app_id {
-            if id.is_empty() {
-                return Err(CommandError::EmptyAppId);
-            }
             manifest.app_id = Some(id);
         }
         let actual_app_id = match manifest.app_id {
             Some(ref id) => id,
-            None => return Err(CommandError::MissingAppId),
+            None => return Err(CommandError::MissingField),
         };
 
         let edge_app_dir = path.parent().ok_or(CommandError::MissingField)?;
@@ -506,7 +503,7 @@ impl EdgeAppCommand {
 
         let mut settings: HashMap<String, serde_yaml::Value> = HashMap::new();
         for setting in &manifest.settings {
-            if setting.type_ != SettingType::Secret {
+            if setting.type_ != "secret" {
                 settings.insert(
                     setting.title.clone(),
                     serde_yaml::Value::String(setting.default_value.clone()),
@@ -548,8 +545,15 @@ impl EdgeAppCommand {
         manifest: &EdgeAppManifest,
         file_tree: HashMap<String, String>,
     ) -> Result<u32, CommandError> {
-        let mut json = EdgeAppManifest::prepare_payload(manifest);
-        json.insert("file_tree", json!(file_tree));
+        let json = json!({
+           "app_id": manifest.app_id,
+           "user_version": manifest.user_version,
+           "description": manifest.description,
+           "icon": manifest.icon,
+           "author": manifest.author,
+           "homepage_url": manifest.homepage_url,
+           "file_tree": file_tree,
+        });
 
         let response = commands::post(
             &self.authentication,
@@ -950,18 +954,6 @@ mod tests {
     use crate::commands::edge_app_server::MOCK_DATA_FILENAME;
     use tempfile::tempdir;
 
-    fn create_edge_app_manifest_for_test(settings: Vec<Setting>) -> EdgeAppManifest {
-        EdgeAppManifest {
-            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
-            user_version: Some("1".to_string()),
-            description: Some("asdf".to_string()),
-            icon: Some("asdf".to_string()),
-            author: Some("asdf".to_string()),
-            homepage_url: Some("asdfasdf".to_string()),
-            settings,
-        }
-    }
-
     #[test]
     fn test_edge_app_create_should_create_app_and_required_files() {
         let tmp_dir = tempdir().unwrap();
@@ -999,7 +991,7 @@ mod tests {
             manifest.settings,
             vec![Setting {
                 title: "greeting".to_string(),
-                type_: SettingType::Secret,
+                type_: "string".to_string(),
                 default_value: "stranger".to_string(),
                 optional: true,
                 help_text: "An example of a setting that is used in index.html".to_string(),
@@ -1336,7 +1328,15 @@ mod tests {
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.list_settings(&manifest.app_id.unwrap());
 
@@ -1453,7 +1453,15 @@ mod tests {
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.set_setting(&manifest.app_id.unwrap(), "best_setting", "best_value");
         installation_mock.assert();
@@ -1527,7 +1535,15 @@ mod tests {
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.set_setting(&manifest.app_id.unwrap(), "best_setting", "best_value1");
         installation_mock.assert();
@@ -1599,7 +1615,15 @@ mod tests {
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.set_secret(
             &manifest.app_id.unwrap(),
@@ -1615,27 +1639,30 @@ mod tests {
 
     #[test]
     fn test_upload_should_send_correct_requests() {
-        let mut manifest = create_edge_app_manifest_for_test(
-            vec![
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![
                 Setting {
-                    type_: SettingType::String,
+                    type_: "string".to_string(),
                     title: "asetting".to_string(),
                     optional: false,
                     default_value: "".to_string(),
                     help_text: "".to_string(),
                 },
                 Setting {
-                    type_: SettingType::String,
+                    type_: "string".to_string(),
                     title: "nsetting".to_string(),
                     optional: false,
                     default_value: "".to_string(),
                     help_text: "".to_string(),
                 },
-            ]
-        );
-
-        manifest.user_version = None;
-        manifest.author = None;
+            ],
+        };
 
         let mock_server = MockServer::start();
         // "v4/assets?select=signature&app_id=eq.{}&app_revision=eq.{}&type=eq.edge-app-file",
@@ -1698,7 +1725,7 @@ mod tests {
                 .query_param("select", "type,default_value,optional,title,help_text")
                 .query_param("order", "title.asc");
             then.status(200).json_body(json!([{
-                "type": SettingType::String,
+                "type": "string".to_string(),
                 "default_value": "5".to_string(),
                 "title": "nsetting".to_string(),
                 "optional": true,
@@ -1713,16 +1740,7 @@ mod tests {
                 .header(
                     "user-agent",
                     format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .json_body(json!({
-                    "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                    "description": "asdf",
-                    "icon": "asdf",
-                    "homepage_url": "asdfasdf",
-                    "file_tree": {
-                        "index.html": "0a209f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08122086cebd0c365d241e32d5b0972c07aae3a8d6499c2a9471aa85943a35577200021a180a14a94a8fe5ccb19ba61c4c0873d391e987982fbbd31000"
-                    }
-                }));
+                );
             then.status(201).json_body(json!([{"revision": 8}]));
         });
 
@@ -1976,7 +1994,15 @@ mod tests {
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.promote_version(&manifest.app_id.unwrap(), 7, &"public".to_string());
 
@@ -1995,24 +2021,30 @@ mod tests {
         let file_path = dir.path().join("test_manifest.yml");
 
         // The EdgeAppManifest structure from your example
-        let manifest = create_edge_app_manifest_for_test(
-            vec![
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![
                 Setting {
-                    type_: SettingType::String,
+                    type_: "string".to_string(),
                     title: "asetting".to_string(),
                     optional: false,
                     default_value: "yes".to_string(),
                     help_text: "".to_string(),
                 },
                 Setting {
-                    type_: SettingType::String,
+                    type_: "string".to_string(),
                     title: "nsetting".to_string(),
                     optional: false,
                     default_value: "".to_string(),
                     help_text: "".to_string(),
                 },
-            ]
-        );
+            ],
+        };
 
         EdgeAppManifest::save_to_file(&manifest, &file_path).unwrap();
         let config = Config::new("".to_owned());
@@ -2044,24 +2076,30 @@ settings:
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("test_manifest_with_varied_settings.yml");
 
-        let manifest = create_edge_app_manifest_for_test( 
-            vec![
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![
                 Setting {
-                    type_: SettingType::Secret,
+                    type_: "secret".to_string(),
                     title: "excluded_setting".to_string(),
                     optional: false,
                     default_value: "0".to_string(),
                     help_text: "".to_string(),
                 },
                 Setting {
-                    type_: SettingType::String,
+                    type_: "string".to_string(),
                     title: "included_setting".to_string(),
                     optional: false,
                     default_value: "".to_string(),
                     help_text: "".to_string(),
                 },
-            ]
-        );
+            ],
+        };
 
         EdgeAppManifest::save_to_file(&manifest, &file_path).unwrap();
         let config = Config::new("".to_owned());
@@ -2078,24 +2116,30 @@ settings:
 
     #[test]
     fn test_ensure_assets_processing_finished_when_processing_failed_should_return_error() {
-        let manifest = create_edge_app_manifest_for_test(
-            vec![
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![
                 Setting {
-                    type_: SettingType::String,
+                    type_: "string".to_string(),
                     title: "asetting".to_string(),
                     optional: false,
                     default_value: "".to_string(),
                     help_text: "".to_string(),
                 },
                 Setting {
-                    type_: SettingType::String,
+                    type_: "string".to_string(),
                     title: "nsetting".to_string(),
                     optional: false,
                     default_value: "".to_string(),
                     help_text: "".to_string(),
                 },
-            ]
-        );
+            ],
+        };
 
         let mock_server = MockServer::start();
 
@@ -2178,7 +2222,15 @@ settings:
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.list_secrets(&manifest.app_id.unwrap());
 
@@ -2266,7 +2318,15 @@ settings:
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.promote_version(&manifest.app_id.unwrap(), 7, &"public".to_string());
 
@@ -2349,7 +2409,15 @@ settings:
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.promote_version(&manifest.app_id.unwrap(), 7, &"public".to_string());
 
@@ -2393,7 +2461,15 @@ settings:
         let config = Config::new(mock_server.base_url());
         let authentication = Authentication::new_with_config(config, "token");
         let command = EdgeAppCommand::new(authentication);
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let result = command.update_name(&manifest.app_id.unwrap(), "New name");
         update_name_mock.assert();
@@ -2425,7 +2501,16 @@ settings:
     #[test]
     fn test_clear_app_id_should_remove_app_id_from_manifest() {
         let mock_server = MockServer::start();
-        let manifest = create_edge_app_manifest_for_test(vec![]);
+
+        let manifest = EdgeAppManifest {
+            app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![],
+        };
 
         let temp_dir = tempdir().unwrap();
         let temp_path = temp_dir.path().join("screenly.yml");
@@ -2442,11 +2527,11 @@ settings:
 
         let expected_manifest = EdgeAppManifest {
             app_id: None,
-            user_version: Some("1".to_string()),
-            description: Some("asdf".to_string()),
-            icon: Some("asdf".to_string()),
-            author: Some("asdf".to_string()),
-            homepage_url: Some("asdfasdf".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
             settings: vec![],
         };
 

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -171,26 +171,25 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use tempfile::tempdir;
-    use crate::commands::SettingType;
 
     fn create_manifest() -> EdgeAppManifest {
         EdgeAppManifest {
             app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
-            user_version: Some("1".to_string()),
-            description: Some("asdf".to_string()),
-            icon: Some("asdf".to_string()),
-            author: Some("asdf".to_string()),
-            homepage_url: Some("asdfasdf".to_string()),
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
             settings: vec![
                 Setting {
-                    type_: SettingType::String,
+                    type_: "string".to_string(),
                     default_value: "5".to_string(),
                     title: "display_time".to_string(),
                     optional: true,
                     help_text: "For how long to display the map overlay every time the rover has moved to a new position.".to_string(),
                 },
                 Setting {
-                    type_: SettingType::String,
+                    type_: "secret".to_string(),
                     default_value: "6".to_string(),
                     title: "google_maps_api_key".to_string(),
                     optional: true,
@@ -207,14 +206,14 @@ mod tests {
 
         let remote_settings = vec![
             Setting {
-                type_: SettingType::String,
+                type_: "string".to_string(),
                 default_value: "5".to_string(),
                 title: "display_time".to_string(),
                 optional: true,
                 help_text: "For how long to display the map overlay every time the rover has moved to a new position.".to_string(),
             },
             Setting {
-                type_: SettingType::String,
+                type_: "secret".to_string(),
                 default_value: "6".to_string(),
                 title: "google_maps_api_key".to_string(),
                 optional: true,
@@ -238,21 +237,21 @@ mod tests {
 
         let remote_settings = vec![
             Setting {
-                type_: SettingType::String,
+                type_: "string".to_string(),
                 default_value: "5".to_string(),
                 title: "display_time".to_string(),
                 optional: true,
                 help_text: "For how long to display the map overlay every time the rover has moved to a new position.".to_string(),
             },
             Setting {
-                type_: SettingType::String,
+                type_: "secret".to_string(),
                 default_value: "6".to_string(),
                 title: "google_maps_api_key".to_string(),
                 optional: true,
                 help_text: "Specify a commercial Google Maps API key. Required due to the app's map feature.".to_string(),
             },
             Setting {
-                type_: SettingType::String,
+                type_: "string".to_string(),
                 default_value: "10".to_string(),
                 title: "new_setting".to_string(),
                 optional: false,
@@ -276,7 +275,7 @@ mod tests {
 
         let remote_settings = vec![
             Setting {
-                type_: SettingType::String,
+                type_: "string".to_string(),
                 default_value: "5".to_string(),
                 title: "display_time".to_string(),
                 optional: true,
@@ -302,14 +301,14 @@ mod tests {
 
         let remote_settings = vec![
             Setting {
-                type_: SettingType::String,
+                type_: "string".to_string(),
                 default_value: "5".to_string(),
                 title: "display_time".to_string(),
                 optional: true,
                 help_text: "For how long to display the map overlay every time the rover has moved to a new position.".to_string(),
             },
             Setting {
-                type_: SettingType::String,
+                type_: "secret".to_string(),
                 default_value: "7".to_string(), // Modified default value
                 title: "google_maps_api_key".to_string(),
                 optional: true,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,13 +7,9 @@ use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
-use std::str::FromStr;
 use std::time::Duration;
 
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::json;
-use strum::IntoEnumIterator;
-use strum_macros::{EnumIter, EnumString, Display};
 
 use thiserror::Error;
 
@@ -117,12 +113,8 @@ pub enum CommandError {
     UndefinedSecrets(String),
     #[error("App id is required. Either in manifest or with --app-id .")]
     MissingAppId,
-    #[error("Non empty App id is required.")]
-    EmptyAppId,
     #[error("Edge App Revision {0} not found")]
     RevisionNotFound(String),
-    #[error("Manifest file validation failed with error: {0}")]
-    InvalidManifest(String),
 }
 
 pub fn get(
@@ -224,44 +216,15 @@ pub fn patch<T: Serialize + ?Sized>(
     }
 }
 
-fn string_field_is_none_or_empty(opt: &Option<String>) -> bool {
-    opt.as_ref().map_or(true, |s| s.is_empty())
-}
-
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EdgeAppManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub app_id: Option<String>,
-    #[serde(
-        deserialize_with = "deserialize_option_string_not_empty",
-        skip_serializing_if = "string_field_is_none_or_empty",
-        default
-    )]
-    pub user_version: Option<String>,
-    #[serde(
-        deserialize_with = "deserialize_option_string_not_empty",
-        skip_serializing_if = "string_field_is_none_or_empty",
-        default
-    )]
-    pub description: Option<String>,
-    #[serde(
-        deserialize_with = "deserialize_option_string_not_empty",
-        skip_serializing_if = "string_field_is_none_or_empty",
-        default
-    )]
-    pub icon: Option<String>,
-    #[serde(
-        deserialize_with = "deserialize_option_string_not_empty",
-        skip_serializing_if = "string_field_is_none_or_empty",
-        default
-    )]
-    pub author: Option<String>,
-    #[serde(
-        deserialize_with = "deserialize_option_string_not_empty",
-        skip_serializing_if = "string_field_is_none_or_empty",
-        default
-    )]
-    pub homepage_url: Option<String>,
+    pub user_version: String,
+    pub description: String,
+    pub icon: String,
+    pub author: String,
+    pub homepage_url: String,
     #[serde(
         serialize_with = "serialize_settings",
         deserialize_with = "deserialize_settings",
@@ -270,24 +233,11 @@ pub struct EdgeAppManifest {
     pub settings: Vec<Setting>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Default, EnumString, Display, EnumIter)]
-pub enum SettingType {
-    #[default]
-    #[strum(serialize = "string")]
-    String,
-    #[strum(serialize = "secret")]
-    Secret,
-}
-
 // maybe we can use a better name as we have EdgeAppSettings which is the same but serde_json::Value inside
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Setting {
-    #[serde(
-        rename = "type", 
-        serialize_with = "serialize_setting_type",
-        deserialize_with = "deserialize_setting_type"
-    )]
-    pub type_: SettingType,
+    #[serde(rename = "type")]
+    pub type_: String,
     #[serde(default)]
     pub default_value: String,
     #[serde(default)]
@@ -325,46 +275,6 @@ where
     map.end()
 }
 
-fn deserialize_option_string_not_empty<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let opt: Option<String> = Option::deserialize(deserializer)?;
-
-    match opt {
-        None => Ok(None),
-        Some(ref s) if s.is_empty() => Err(serde::de::Error::custom("String cannot be empty")),
-        _ => Ok(opt),
-    }
-}
-
-fn serialize_setting_type<S>(setting_type: &SettingType, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(&setting_type.to_string())
-}
-
-fn deserialize_setting_type<'de, D>(deserializer: D) -> Result<SettingType, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: String = Deserialize::deserialize(deserializer)?;
-
-    let valid_setting_types = SettingType::iter()
-        .map(|t| t.to_string())
-        .collect::<Vec<_>>()
-        .join("\n") + "\n";
-
-    match SettingType::from_str(&s.to_lowercase()) {
-        Ok(setting_type) => Ok(setting_type),
-        Err(_) => Err(serde::de::Error::custom(format!(
-            "Field type should be one of the following:\n{}",
-            valid_setting_types
-        ))),
-    }
-}
-
 impl EdgeAppManifest {
     pub fn new(path: &Path) -> Result<Self, CommandError> {
         let data = fs::read_to_string(path)?;
@@ -377,29 +287,6 @@ impl EdgeAppManifest {
         let manifest_file = File::create(path)?;
         write!(&manifest_file, "---\n{yaml}")?;
         Ok(())
-    }
-
-    fn prepare_payload(manifest: &EdgeAppManifest) -> HashMap<&str, serde_json::Value> {
-        [
-            ("app_id", &manifest.app_id),
-            ("user_version", &manifest.user_version),
-            ("description", &manifest.description),
-            ("icon", &manifest.icon),
-            ("author", &manifest.author),
-            ("homepage_url", &manifest.homepage_url),
-        ]
-        .iter()
-        .filter_map(|(key, value)| value.as_ref().map(|v| (*key, json!(v))))
-        .collect()
-    }
-
-    pub fn ensure_manifest_is_validated(path: &Path) -> Result<(), CommandError> {
-        match EdgeAppManifest::new(path) {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                Err(CommandError::InvalidManifest(e.to_string()))
-            }
-        }
     }
 }
 
@@ -772,150 +659,16 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    fn write_to_tempfile(dir: &tempfile::TempDir, file_name: &str, content: &str) -> std::path::PathBuf {
-        let file_path = dir.path().join(file_name);
-        std::fs::write(&file_path, content).unwrap();
-        file_path
-    }
-
     #[test]
-    fn test_save_manifest_to_file_should_save_yaml_correctly() {
+    fn test_save_to_file_should_save_yaml_correctly() {
         let dir = tempdir().unwrap();
-        let file_path = dir.path().join("screenly.yml");
-
-        let manifest = EdgeAppManifest {
-            app_id: Some("test_app".to_string()),
-            user_version: Some("test_version".to_string()),
-            description: Some("test_description".to_string()),
-            icon: Some("test_icon".to_string()),
-            author: Some("test_author".to_string()),
-            homepage_url: Some("test_url".to_string()),
-            settings: vec![Setting {
-                title: "username".to_string(),
-                type_: SettingType::String,
-                default_value: "stranger".to_string(),
-                optional: true,
-                help_text: "An example of a setting that is used in index.html".to_string(),
-            }]
-        };
-
-        EdgeAppManifest::save_to_file(&manifest, &file_path).unwrap();
-
-        let contents = fs::read_to_string(file_path).unwrap();
-
-        let expected_contents = r#"---
-app_id: test_app
-user_version: test_version
-description: test_description
-icon: test_icon
-author: test_author
-homepage_url: test_url
-settings:
-  username:
-    type: string
-    default_value: stranger
-    title: username
-    optional: true
-    help_text: An example of a setting that is used in index.html
-"#;
-
-        assert_eq!(contents, expected_contents);
-    }
-
-    #[test]
-    fn test_save_manifest_to_file_should_skip_none_optional_fields() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("screenly.yml");
-
-        let manifest = EdgeAppManifest {
-            app_id: Some("test_app".to_string()),
-            user_version: Some("test_version".to_string()),
-            description: None,
-            icon: Some("test_icon".to_string()),
-            author: None,
-            homepage_url: Some("test_url".to_string()),
-            settings: vec![Setting {
-                title: "username".to_string(),
-                type_: SettingType::String,
-                default_value: "stranger".to_string(),
-                optional: true,
-                help_text: "An example of a setting that is used in index.html".to_string(),
-            }]
-        };
-
-        EdgeAppManifest::save_to_file(&manifest, &file_path).unwrap();
-
-        let contents = fs::read_to_string(file_path).unwrap();
-
-        let expected_contents = r#"---
-app_id: test_app
-user_version: test_version
-icon: test_icon
-homepage_url: test_url
-settings:
-  username:
-    type: string
-    default_value: stranger
-    title: username
-    optional: true
-    help_text: An example of a setting that is used in index.html
-"#;
-
-        assert_eq!(contents, expected_contents);
-    }
-
-    #[test]
-    fn test_save_manifest_to_file_should_skip_empty_optional_fields() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("screenly.yml");
-
-        let manifest = EdgeAppManifest {
-            app_id: Some("test_app".to_string()),
-            user_version: Some("test_version".to_string()),
-            description: Some("".to_string()),
-            icon: Some("test_icon".to_string()),
-            author: Some("".to_string()),
-            homepage_url: Some("test_url".to_string()),
-            settings: vec![Setting {
-                title: "username".to_string(),
-                type_: SettingType::String,
-                default_value: "stranger".to_string(),
-                optional: true,
-                help_text: "An example of a setting that is used in index.html".to_string(),
-            }]
-        };
-
-        EdgeAppManifest::save_to_file(&manifest, &file_path).unwrap();
-
-        let contents = fs::read_to_string(file_path).unwrap();
-
-        let expected_contents = r#"---
-app_id: test_app
-user_version: test_version
-icon: test_icon
-homepage_url: test_url
-settings:
-  username:
-    type: string
-    default_value: stranger
-    title: username
-    optional: true
-    help_text: An example of a setting that is used in index.html
-"#;
-
-        assert_eq!(contents, expected_contents);
-    }
-
-    #[test]
-    fn test_save_manifest_to_file_should_skip_default_optional_fields() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("screenly.yml");
+        let file_path = dir.path().join("test.yaml");
 
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
             settings: vec![Setting {
                 title: "username".to_string(),
-                type_: SettingType::String,
+                type_: "string".to_string(),
                 default_value: "stranger".to_string(),
                 optional: true,
                 help_text: "An example of a setting that is used in index.html".to_string(),
@@ -929,71 +682,10 @@ settings:
 
         let expected_contents = r#"---
 app_id: test_app
-settings:
-  username:
-    type: string
-    default_value: stranger
-    title: username
-    optional: true
-    help_text: An example of a setting that is used in index.html
-"#;
-
-        assert_eq!(contents, expected_contents);
-    }
-
-    #[test]
-    fn test_ensure_manifest_is_validated_when_file_non_existent_should_return_error() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("screenly.yml");
-    
-        assert!(EdgeAppManifest::ensure_manifest_is_validated(&file_path).is_err());
-    }
-
-    #[test]
-    fn test_ensure_manifest_is_validated_when_file_valid_should_return_ok() {
-        let dir = tempdir().unwrap();
-        let file_name = "screenly.yml";
-        let content = r#"---
-app_id: test_app
-settings:
-  username:
-    type: string
-    default_value: stranger
-    title: username
-    optional: true
-    help_text: An example of a setting that is used in index.html
-"#;
-
-        write_to_tempfile(&dir, file_name, content);
-        let file_path = dir.path().join(file_name);        
-        assert!(EdgeAppManifest::ensure_manifest_is_validated(&file_path).is_ok());
-    }
-
-    #[test]
-    fn test_ensure_manifest_is_validated_when_missing_field_should_return_error() {
-        let dir = tempdir().unwrap();
-        let file_name = "screenly.yml";
-        let content = r#"---
-app_id: test_app
-settings:
-  username:
-    type: string
-    default_value: stranger
-    title: username
-    help_text: An example of a setting that is used in index.html
-"#;
-
-        write_to_tempfile(&dir, file_name, content);
-        let file_path = dir.path().join(file_name);
-        assert!(EdgeAppManifest::ensure_manifest_is_validated(&file_path).is_err());
-    }
-
-    #[test]
-    fn test_ensure_manifest_is_validated_when_empty_field_should_return_error() {
-        let dir = tempdir().unwrap();
-        let file_name = "screenly.yml";
-        let content = r#"---
-app_id: test_app
+user_version: ''
+description: ''
+icon: ''
+author: ''
 homepage_url: ''
 settings:
   username:
@@ -1004,29 +696,7 @@ settings:
     help_text: An example of a setting that is used in index.html
 "#;
 
-        write_to_tempfile(&dir, file_name, content);
-        let file_path = dir.path().join(file_name);        
-        assert!(EdgeAppManifest::ensure_manifest_is_validated(&file_path).is_err());
-    }
-
-    #[test]
-    fn test_ensure_manifest_is_validated_when_invaild_type_should_return_error() {
-        let dir = tempdir().unwrap();
-        let file_name = "screenly.yml";
-        let content = r#"---
-app_id: test_app
-settings:
-  username:
-    type: bool
-    default_value: stranger
-    title: username
-    optional: true
-    help_text: An example of a setting that is used in index.html
-"#;
-
-        write_to_tempfile(&dir, file_name, content);
-        let file_path = dir.path().join(file_name);        
-        assert!(EdgeAppManifest::ensure_manifest_is_validated(&file_path).is_err());
+        assert_eq!(contents, expected_contents);
     }
 
     #[test]
@@ -1053,6 +723,7 @@ settings:
             "published": true
         }]"#;
         let edge_app_versions = EdgeAppVersions::new(serde_json::from_str(data).unwrap());
+
         let output = edge_app_versions.format(OutputType::HumanReadable);
         assert_eq!(
             output,
@@ -1066,53 +737,4 @@ settings:
 "#
         );
     }
-
-    #[test]
-    fn test_prepare_manifest_payload_includes_some_fields() {
-        let manifest = EdgeAppManifest {
-            app_id: Some("test_app".to_string()),
-            user_version: Some("test_version".to_string()),
-            description: Some("test_description".to_string()),
-            icon: Some("test_icon".to_string()),
-            author: Some("test_author".to_string()),
-            homepage_url: Some("test_url".to_string()),
-            settings: vec![Setting {
-                title: "username".to_string(),
-                type_: SettingType::String,
-                default_value: "stranger".to_string(),
-                optional: true,
-                help_text: "An example of a setting that is used in index.html".to_string(),
-            }]
-        };
-
-        let result = EdgeAppManifest::prepare_payload(&manifest);
-        assert_eq!(result["app_id"], json!("test_app"));
-        assert_eq!(result["user_version"], json!("test_version"));
-        assert_eq!(result["description"], json!("test_description"));
-        assert_eq!(result["icon"], json!("test_icon"));
-        assert_eq!(result["author"], json!("test_author"));
-        assert_eq!(result["homepage_url"], json!("test_url"));
-    }
-
-    #[test]
-    fn test_prepare_manifest_payload_omits_none_fields() {
-        let manifest = EdgeAppManifest {
-            app_id: Some("test_app".to_string()),
-            user_version: None,
-            description: Some("test_description".to_string()),
-            icon: Some("test_icon".to_string()),
-            author: None,
-            homepage_url: Some("test_url".to_string()),
-            ..Default::default()
-        };
-
-        let result = EdgeAppManifest::prepare_payload(&manifest);
-        assert_eq!(result["app_id"], json!("test_app"));
-        assert_eq!(result.contains_key("user_version"), false);
-        assert_eq!(result["description"], json!("test_description"));
-        assert_eq!(result["icon"], json!("test_icon"));
-        assert_eq!(result.contains_key("author"), false);
-        assert_eq!(result["homepage_url"], json!("test_url"));
-    }
 }
-


### PR DESCRIPTION
Reverts Screenly/cli#96

Not applied to settings/incorrectly does not allow empty optional fields (description/icon)