### PR TITLE
Adds: proper error when app_id is missing on upload.

### DIFF
--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -2618,6 +2618,7 @@ settings:
 
         let manifest = EdgeAppManifest {
             app_id: None,
+            entrypoint: None,
             user_version: "1".to_string(),
             description: "asdf".to_string(),
             icon: "asdf".to_string(),

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -328,7 +328,7 @@ impl EdgeAppCommand {
         }
         let actual_app_id = match manifest.app_id {
             Some(ref id) => id,
-            None => return Err(CommandError::MissingField),
+            None => return Err(CommandError::MissingAppId),
         };
 
         let edge_app_dir = path.parent().ok_or(CommandError::MissingField)?;
@@ -2536,5 +2536,54 @@ settings:
         };
 
         assert_eq!(new_manifest, expected_manifest);
+    }
+
+    #[test]
+    fn test_upload_without_app_id_should_fail() {
+        let mock_server = MockServer::start();
+
+        let manifest = EdgeAppManifest {
+            app_id: None,
+            user_version: "1".to_string(),
+            description: "asdf".to_string(),
+            icon: "asdf".to_string(),
+            author: "asdf".to_string(),
+            homepage_url: "asdfasdf".to_string(),
+            settings: vec![
+                Setting {
+                    type_: "string".to_string(),
+                    title: "asetting".to_string(),
+                    optional: false,
+                    default_value: "".to_string(),
+                    help_text: "".to_string(),
+                },
+                Setting {
+                    type_: "string".to_string(),
+                    title: "nsetting".to_string(),
+                    optional: false,
+                    default_value: "".to_string(),
+                    help_text: "".to_string(),
+                },
+            ],
+        };
+
+        let temp_dir = tempdir().unwrap();
+        EdgeAppManifest::save_to_file(&manifest, temp_dir.path().join("screenly.yml").as_path())
+            .unwrap();
+        let mut file = File::create(temp_dir.path().join("index.html")).unwrap();
+        write!(file, "test").unwrap();
+
+        EdgeAppManifest::save_to_file(&manifest, temp_dir.path().join("screenly.yml").as_path())
+            .unwrap();
+        let config = Config::new(mock_server.base_url());
+        let authentication = Authentication::new_with_config(config, "token");
+        let command = EdgeAppCommand::new(authentication);
+        let result = command.upload(temp_dir.path().join("screenly.yml").as_path(), None);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "App id is required. Either in manifest or with --app-id."
+        );
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -111,7 +111,7 @@ pub enum CommandError {
     AssetProcessingError(String),
     #[error("Warning: these secrets are undefined: {0}.")]
     UndefinedSecrets(String),
-    #[error("App id is required. Either in manifest or with --app-id .")]
+    #[error("App id is required. Either in manifest or with --app-id.")]
     MissingAppId,
     #[error("Edge App Revision {0} not found")]
     RevisionNotFound(String),


### PR DESCRIPTION
Refs https://phorge.wireload.net/T7529

Throw proper error when app_id is missing on upload.

Other cases should be covered properly.