### PR TITLE
Generate mock data subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -318,8 +318,8 @@ pub enum EdgeAppCommands {
         secrets: Option<Secrets>,
 
         /// Generates mock data to be used with Edge App run
-        #[arg(long)]
-        generate_mock_data: bool,
+        #[arg(short, long, action = clap::ArgAction::SetTrue)]
+        generate_mock_data: Option<bool>,
     },
 
     /// Version commands.
@@ -1153,7 +1153,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 Vec::new()
             };
 
-            if *generate_mock_data {
+            if generate_mock_data.unwrap_or(false) {
                 let manifest_path = transform_edge_app_path_to_manifest(path);
                 match edge_app_command.generate_mock_data(&manifest_path) {
                     Ok(_) => std::process::exit(0),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1158,7 +1158,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 match edge_app_command.generate_mock_data(&manifest_path) {
                     Ok(_) => std::process::exit(0),
                     Err(e) => {
-                        eprintln!("Failed to generate mock data: {e}.");
+                        eprintln!("Mock data generation failed: {e}.");
                         std::process::exit(1);
                     }
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -316,13 +316,10 @@ pub enum EdgeAppCommands {
 
         #[arg(short, long, value_parser = parse_key_values::<Secrets>)]
         secrets: Option<Secrets>,
-    },
 
-    // Generates mock data to be used with Edge App run.
-    GenerateMockData {
-        /// Path to the directory with the manifest. If not specified CLI will use the current working directory.
-        #[arg(short, long)]
-        path: Option<String>,
+        /// Generate mock data when running the emulator.
+        #[arg(long)]
+        generate_mock_data: bool,
     },
 
     /// Version commands.
@@ -1145,26 +1142,33 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 }
             }
         }
-        EdgeAppCommands::Run { path, secrets } => {
+        EdgeAppCommands::Run {
+            path,
+            secrets,
+            generate_mock_data,
+        } => {
             let secrets = if let Some(secret_pairs) = secrets {
                 secret_pairs.secrets.clone()
             } else {
                 Vec::new()
             };
+
+            if *generate_mock_data {
+                let manifest_path = transform_edge_app_path_to_manifest(path);
+                edge_app_command.generate_mock_data(&manifest_path).unwrap();
+            }
+
             let path = match path {
                 Some(path) => PathBuf::from(path),
                 None => env::current_dir().unwrap(),
             };
+
             if !path.join(MOCK_DATA_FILENAME).exists() {
-                eprintln!("Error: No mock-data exist. Please run \"screenly edge-app generate-mock-data\" and try again.");
+                eprintln!("Error: No mock-data exist. Please run \"screenly edge-app run --generate-mock-data\".");
                 std::process::exit(1);
             }
 
             edge_app_command.run(path.as_path(), secrets).unwrap();
-        }
-        EdgeAppCommands::GenerateMockData { path } => {
-            let manifest_path = transform_edge_app_path_to_manifest(path);
-            edge_app_command.generate_mock_data(&manifest_path).unwrap();
         }
         EdgeAppCommands::Validate { path } => {
             let manifest_path = transform_edge_app_path_to_manifest(path);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -317,7 +317,7 @@ pub enum EdgeAppCommands {
         #[arg(short, long, value_parser = parse_key_values::<Secrets>)]
         secrets: Option<Secrets>,
 
-        /// Generate mock data when running the emulator.
+        /// Generates mock data to be used with Edge App run
         #[arg(long)]
         generate_mock_data: bool,
     },
@@ -1155,7 +1155,13 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
 
             if *generate_mock_data {
                 let manifest_path = transform_edge_app_path_to_manifest(path);
-                edge_app_command.generate_mock_data(&manifest_path).unwrap();
+                match edge_app_command.generate_mock_data(&manifest_path) {
+                    Ok(_) => std::process::exit(0),
+                    Err(e) => {
+                        eprintln!("Failed to generate mock data: {e}.");
+                        std::process::exit(1);
+                    }
+                }
             }
 
             let path = match path {
@@ -1164,7 +1170,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             };
 
             if !path.join(MOCK_DATA_FILENAME).exists() {
-                eprintln!("Error: No mock-data exist. Please run \"screenly edge-app run --generate-mock-data\".");
+                eprintln!("Error: No mock-data exist. Please run \"screenly edge-app run --generate-mock-data\" and try again.");
                 std::process::exit(1);
             }
 

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -306,7 +306,7 @@ impl EdgeAppCommand {
             }
 
             println!(
-                "Edge app emulator is running at {}/index.html",
+                "Edge App emulator is running at {}/index.html",
                 address_shared.lock().unwrap().as_ref().unwrap()
             );
 
@@ -503,7 +503,7 @@ impl EdgeAppCommand {
         let edge_app_dir = path.parent().ok_or(CommandError::MissingField)?;
 
         if edge_app_dir.join(MOCK_DATA_FILENAME).exists() {
-            println!("Mock data for Edge App Emulator already exists.");
+            println!("Mock data for Edge App emulator already exists.");
             return Ok(());
         }
 
@@ -530,7 +530,7 @@ impl EdgeAppCommand {
 
         fs::write(edge_app_dir.join(MOCK_DATA_FILENAME), mock_data_yaml)?;
 
-        println!("Generated mock data for Edge App Emulator.");
+        println!("Mock data for Edge App emulator was generated.");
         Ok(())
     }
     fn get_undefined_secrets(&self, app_id: &str) -> Result<Vec<String>, CommandError> {

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -530,7 +530,7 @@ impl EdgeAppCommand {
 
         fs::write(edge_app_dir.join(MOCK_DATA_FILENAME), mock_data_yaml)?;
 
-        println!("Generated mock data for Edge App Emulator.");        
+        println!("Generated mock data for Edge App Emulator.");
         Ok(())
     }
     fn get_undefined_secrets(&self, app_id: &str) -> Result<Vec<String>, CommandError> {

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -502,6 +502,11 @@ impl EdgeAppCommand {
         let manifest: EdgeAppManifest = serde_yaml::from_str(&data)?;
         let edge_app_dir = path.parent().ok_or(CommandError::MissingField)?;
 
+        if edge_app_dir.join(MOCK_DATA_FILENAME).exists() {
+            println!("Mock data for Edge App Emulator already exists.");
+            return Ok(());
+        }
+
         let default_metadata = Metadata::default();
 
         let mut settings: HashMap<String, serde_yaml::Value> = HashMap::new();
@@ -525,6 +530,7 @@ impl EdgeAppCommand {
 
         fs::write(edge_app_dir.join(MOCK_DATA_FILENAME), mock_data_yaml)?;
 
+        println!("Generated mock data for Edge App Emulator.");        
         Ok(())
     }
     fn get_undefined_secrets(&self, app_id: &str) -> Result<Vec<String>, CommandError> {


### PR DESCRIPTION
## What does this PR do?
Moves `generate-mock-data` to a sub-command for `run`

## How has this been tested?
- Unit tests pass after this change
- **Manual tests**

This is how `run` looks now: 
![image](https://github.com/Screenly/cli/assets/135842671/1eb75077-52bd-42c9-bd82-cd359a919e27)

This are new messages in `cli` after this change:
![image](https://github.com/Screenly/cli/assets/135842671/58905e71-326e-45e4-a874-e3dc6caaa2b1)
