### PR TITLE
Remove custom deserializer

### DIFF
--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -2657,8 +2657,8 @@ settings:
         let mut file2 = File::create(temp_dir.path().join("index2.html")).unwrap();
         write!(file2, "test333").unwrap();
 
-        let mut changed_files = FileChanges::new(
-            &vec![
+        let changed_files = FileChanges::new(
+            &[
                 EdgeAppFile {
                     path: "index.html".to_owned(),
                     signature: "somesig".to_owned(),
@@ -2679,7 +2679,7 @@ settings:
             edge_app_dir,
             "01H2QZ6Z8WXWNDC0KQ198XCZEW",
             7,
-            &mut changed_files,
+            &changed_files,
         );
 
         // Twice for somesig1 and somesig2
@@ -2764,8 +2764,8 @@ settings:
         let mut file2 = File::create(temp_dir.path().join("index2.html")).unwrap();
         write!(file2, "test333").unwrap();
 
-        let mut changed_files = FileChanges::new(
-            &vec![
+        let changed_files = FileChanges::new(
+            &[
                 EdgeAppFile {
                     path: "index.html".to_owned(),
                     signature: "somesig".to_owned(),
@@ -2786,7 +2786,7 @@ settings:
             edge_app_dir,
             "01H2QZ6Z8WXWNDC0KQ198XCZEW",
             7,
-            &mut changed_files,
+            &changed_files,
         );
 
         upload_assets_mock.assert_hits(0);

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -619,11 +619,11 @@ settings:
 
         let result = EdgeAppManifest::prepare_payload(&manifest);
         assert_eq!(result["app_id"], json!("test_app"));
-        assert_eq!(result.contains_key("user_version"), false);
+        assert!(!result.contains_key("user_version"));
         assert_eq!(result["description"], json!("test_description"));
         assert_eq!(result["icon"], json!("test_icon"));
-        assert_eq!(result.contains_key("author"), false);
+        assert!(!result.contains_key("author"));
         assert_eq!(result["homepage_url"], json!("test_url"));
-        assert_eq!(result.contains_key("entrypoint"), false);
+        assert!(!result.contains_key("entrypoint"));
     }
 }

--- a/src/commands/edge_app_server.rs
+++ b/src/commands/edge_app_server.rs
@@ -1,7 +1,7 @@
 use crate::commands::ignorer::Ignorer;
 use anyhow::Result;
 use futures::future::{self, BoxFuture, FutureExt};
-use std::collections::{HashMap};
+use std::collections::HashMap;
 use std::fs;
 
 use serde::{Deserialize, Serialize};
@@ -127,7 +127,14 @@ async fn generate_content(
         );
         return Err(warp::reject::not_found());
     };
-    let data: MockData = serde_yaml::from_str(&content).expect("Failed to deserialize.");
+    let data: MockData = match serde_yaml::from_str(&content) {
+        Ok(data) => data,
+        Err(e) => {
+            eprintln!("Failed to parse mock data: {}", e);
+            return Err(warp::reject::not_found());
+        }
+    };
+
     let js_output = format_js(data, secrets);
 
     Ok(warp::reply::html(js_output))

--- a/src/commands/edge_app_server.rs
+++ b/src/commands/edge_app_server.rs
@@ -1,7 +1,7 @@
 use crate::commands::ignorer::Ignorer;
 use anyhow::Result;
 use futures::future::{self, BoxFuture, FutureExt};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{HashMap};
 use std::fs;
 
 use serde::{Deserialize, Serialize};
@@ -110,42 +110,7 @@ impl Default for Metadata {
 #[derive(Debug, Default, Deserialize)]
 struct MockData {
     metadata: Metadata,
-    settings: Vec<(String, Value)>,
-}
-
-#[derive(Debug, Default, Deserialize, Clone)]
-struct MockDataStr {
-    metadata: Metadata,
-    settings: BTreeMap<String, String>,
-}
-
-impl MockData {
-    fn new_from_str(mock_data_str: &MockDataStr) -> Self {
-        let settings_val = mock_data_str
-            .settings
-            .iter()
-            .map(|(k, v)| {
-                if v.len() > 2
-                    && v.chars().nth(0) == Some('[')
-                    && v.chars().nth(v.len() - 1) == Some(']')
-                {
-                    let v = &v[1..(v.len() - 1)];
-                    let v = v
-                        .split(',')
-                        .map(|s| s.trim().replace(['"', '\''], ""))
-                        .collect::<Vec<_>>();
-                    (k.clone(), Value::Array(v.clone()))
-                } else {
-                    (k.clone(), Value::Str(v.clone()))
-                }
-            })
-            .collect::<Vec<(_, _)>>();
-
-        MockData {
-            metadata: mock_data_str.metadata.clone(),
-            settings: settings_val,
-        }
-    }
+    settings: HashMap<String, String>,
 }
 
 async fn generate_content(
@@ -162,26 +127,25 @@ async fn generate_content(
         );
         return Err(warp::reject::not_found());
     };
-
-    let data_str: MockDataStr = match serde_yaml::from_str(&content) {
-        Ok(data_str) => data_str,
-        Err(e) => {
-            eprintln!("Mock data deserialization Error: {:?}. Use \"edge-app run --generate-mock-data\" to create mock data.", e);
-            return Err(warp::reject::not_found());
-        }
-    };
-
-    let data = MockData::new_from_str(&data_str);
+    let data: MockData = serde_yaml::from_str(&content).expect("Failed to deserialize.");
     let js_output = format_js(data, secrets);
 
     Ok(warp::reply::html(js_output))
 }
 
 fn format_js(data: MockData, secrets: &[(String, Value)]) -> String {
+    let mut settings: Vec<(String, Value)> = data
+        .settings
+        .into_iter()
+        .map(|(k, v)| (k, Value::Str(v)))
+        .collect();
+
+    settings.sort_by_key(|a| a.0.clone());
+
     format!(
         "var screenly = {{\n{metadata},\n{settings},\n{secrets},\n{cors_proxy}\n}};",
         metadata = format_section("metadata", &hashmap_from_metadata(&data.metadata)),
-        settings = format_section("settings", &data.settings),
+        settings = format_section("settings", &settings),
         secrets = format_section("secrets", secrets),
         cors_proxy = "    cors_proxy_url: \"http://127.0.0.1:8080\""
     )
@@ -340,22 +304,5 @@ settings:
             .unwrap();
 
         assert_eq!(resp.status(), 404);
-    }
-
-    #[tokio::test]
-    async fn test_server_mockdata_str_should_obtain_mockdata_from_str() {
-        let metadata = Metadata::default();
-        let mut settings = BTreeMap::new();
-
-        settings.insert("enable_analytics".to_string(), "true".to_string());
-        settings.insert("override_timezone".to_string(), "".to_string());
-        settings.insert("tag_manager_id".to_string(), "".to_string());
-
-        let mockdata_str = MockDataStr { metadata, settings };
-        let mockdata = MockData::new_from_str(&mockdata_str);
-        let (k, v) = mockdata.settings.first().unwrap();
-
-        assert_eq!(*k, "enable_analytics");
-        assert_eq!(*v, Value::Str("true".to_string()));
     }
 }


### PR DESCRIPTION
## What does this PR do?
Removes custom serializer. Simplifies data structure.

## GitHub issue or Phabricator ticket number?
https://github.com/Screenly/cli/issues/119

## How has this been tested?
All tests pass and `edge-app run` with hello world works in the browser..
## Checklist before merging

- [ ] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
