### PR TITLE
Adds: build variable for api server url

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ $ cargo build --release
 the `screenly` binary will be located in `target/release` directory.
 
 
+
+To utilize an alternative API server (non-production), employ the API_SERVER_NAME environment variable for configuring the desired API server URL. Available options include: 'prod', 'local', and 'stage'.
+
+```bash
+$ API_SERVER_NAME=local cargo build --release
+```
+
+```bash
+
+
 ## GitHub Action
 
 Our CLI is also available as a GitHub Action workflow.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,35 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+const CONFIG: &str = "config.rs";
+const LOCAL_API_URL: &str = "https://login.screenly.local/api";
+const STAGE_API_URL: &str = "https://api.screenlyappstage.com/api";
+const PROD_API_URL: &str = "https://api.screenlyapp.com/api";
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join(CONFIG);
+
+    let api_server = match env::var_os("API_SERVER_NAME") {
+        Some(val) => {
+            let api_server_name = val.into_string().unwrap();
+            match api_server_name.as_str() {
+                "local" => LOCAL_API_URL,
+                "stage" => STAGE_API_URL,
+                "prod" => PROD_API_URL,
+                _ => {
+                    panic!("Invalid API_SERVER_NAME. Use one of: local, stage, prod");
+                }
+            }
+        }
+        None => PROD_API_URL,
+    };
+    fs::write(
+        dest_path,
+        format!("pub const API_BASE_URL: &str = \"{}\";", api_server),
+    )
+    .unwrap();
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=API_SERVER_NAME");
+}

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -4,11 +4,9 @@ use reqwest::header::{HeaderMap, InvalidHeaderValue};
 use reqwest::{header, StatusCode};
 use thiserror::Error;
 
-// const API_BASE_URL: &str = "https://api.screenlyappstage.com/api";
-const API_BASE_URL: &str = "https://api.screenlyapp.com/api";
-// use this one for local development
-// but also uncomment unsafe certificate lines "danger_accept_invalid_certs(true)".
-// const API_BASE_URL: &str = "https://login.screenly.local/api";
+include!(concat!(env!("OUT_DIR"), "/config.rs"));
+// for local development
+// also uncomment unsafe certificate lines "danger_accept_invalid_certs(true)".
 
 pub struct Config {
     pub url: String,


### PR DESCRIPTION
Refs https://phorge.wireload.net/T7472

We want to freeze API URL during the building time.
Required for our integration tests and will be also convenient during development - building once, w/o commenting/uncommenting API_BASE_URL.
Also I decided not to provide url, but provide aliases during build time - local, stage or prod, prod being default of course.

build script is based on rust examples https://doc.rust-lang.org/cargo/reference/build-script-examples.html

`API_SERVER_NAME=local cargo build`