### PR TITLE
Updates: required string can lack default_value. Updated undefined ap…

### DIFF
--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -406,9 +406,9 @@ impl EdgeAppCommand {
         revision: u32,
         channel: &String,
     ) -> Result<(), CommandError> {
-        let secrets = self.get_undefined_secrets(app_id)?;
+        let secrets = self.get_undefined_settings(app_id)?;
         if !secrets.is_empty() {
-            return Err(CommandError::UndefinedSecrets(serde_json::to_string(
+            return Err(CommandError::UndefinedSettings(serde_json::to_string(
                 &secrets,
             )?));
         }
@@ -548,10 +548,10 @@ impl EdgeAppCommand {
         println!("Mock data for Edge App emulator was generated.");
         Ok(())
     }
-    fn get_undefined_secrets(&self, app_id: &str) -> Result<Vec<String>, CommandError> {
+    fn get_undefined_settings(&self, app_id: &str) -> Result<Vec<String>, CommandError> {
         let installation_id = self.get_or_create_installation(app_id)?;
 
-        let undefined_secrets_response = commands::get(
+        let undefined_settings_response = commands::get(
             &self.authentication,
             &format!(
                 "v4/edge-apps/settings/undefined?installation_id={}",
@@ -559,7 +559,7 @@ impl EdgeAppCommand {
             ),
         )?;
 
-        let titles = serde_json::from_value::<Vec<String>>(undefined_secrets_response)?;
+        let titles = serde_json::from_value::<Vec<String>>(undefined_settings_response)?;
 
         Ok(titles)
     }
@@ -2005,7 +2005,7 @@ mod tests {
         });
 
         //  v4/edge-apps/settings?select=type,default_value,optional,title,help_text&app_id=eq.{}&order=title.asc
-        let undefined_secrets_mock = mock_server.mock(|when, then| {
+        let undefined_settings_mock = mock_server.mock(|when, then| {
             when.method(GET)
                 .path("/v4/edge-apps/settings/undefined")
                 .header("Authorization", "Token token")
@@ -2049,7 +2049,7 @@ mod tests {
         get_version_mock.assert();
         installation_mock.assert();
         installation_mock_create.assert();
-        undefined_secrets_mock.assert();
+        undefined_settings_mock.assert();
         promote_mock.assert();
 
         assert!(&result.is_ok());
@@ -2270,7 +2270,7 @@ settings:
     }
 
     #[test]
-    fn test_promote_when_there_are_undefined_secrets_should_fail() {
+    fn test_promote_when_there_are_undefined_settings_should_fail() {
         let mock_server = MockServer::start();
 
         let installation_mock = mock_server.mock(|when, then| {
@@ -2310,7 +2310,7 @@ settings:
         });
 
         //  v4/edge-apps/settings?select=type,default_value,optional,title,help_text&app_id=eq.{}&order=title.asc
-        let undefined_secrets_mock = mock_server.mock(|when, then| {
+        let undefined_settings_mock = mock_server.mock(|when, then| {
             when.method(GET)
                 .path("/v4/edge-apps/settings/undefined")
                 .header("Authorization", "Token token")
@@ -2332,7 +2332,7 @@ settings:
 
         installation_mock.assert();
         installation_mock_create.assert();
-        undefined_secrets_mock.assert();
+        undefined_settings_mock.assert();
 
         assert!(!&result.is_ok());
         assert!(result.unwrap_err().to_string().contains("Warning: these settings are required to be defined: [\"undefined_secret\",\"another_undefined_secret\"]."));
@@ -2394,7 +2394,7 @@ settings:
         });
 
         //  v4/edge-apps/settings?select=type,default_value,optional,title,help_text&app_id=eq.{}&order=title.asc
-        let undefined_secrets_mock = mock_server.mock(|when, then| {
+        let undefined_settings_mock = mock_server.mock(|when, then| {
             when.method(GET)
                 .path("/v4/edge-apps/settings/undefined")
                 .header("Authorization", "Token token")
@@ -2416,7 +2416,7 @@ settings:
         get_version_mock.assert();
         installation_mock.assert();
         installation_mock_create.assert();
-        undefined_secrets_mock.assert();
+        undefined_settings_mock.assert();
 
         assert!(!&result.is_ok());
         assert!(result

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -413,7 +413,7 @@ impl EdgeAppCommand {
             )?));
         }
 
-        debug!("All secrets are defined.");
+        debug!("All settings are defined.");
 
         let get_response = commands::get(
             &self.authentication,
@@ -554,7 +554,7 @@ impl EdgeAppCommand {
         let undefined_secrets_response = commands::get(
             &self.authentication,
             &format!(
-                "v4/edge-apps/secrets/undefined?installation_id={}",
+                "v4/edge-apps/settings/undefined?installation_id={}",
                 installation_id
             ),
         )?;
@@ -2007,7 +2007,7 @@ mod tests {
         //  v4/edge-apps/settings?select=type,default_value,optional,title,help_text&app_id=eq.{}&order=title.asc
         let undefined_secrets_mock = mock_server.mock(|when, then| {
             when.method(GET)
-                .path("/v4/edge-apps/secrets/undefined")
+                .path("/v4/edge-apps/settings/undefined")
                 .header("Authorization", "Token token")
                 .header(
                     "user-agent",
@@ -2312,7 +2312,7 @@ settings:
         //  v4/edge-apps/settings?select=type,default_value,optional,title,help_text&app_id=eq.{}&order=title.asc
         let undefined_secrets_mock = mock_server.mock(|when, then| {
             when.method(GET)
-                .path("/v4/edge-apps/secrets/undefined")
+                .path("/v4/edge-apps/settings/undefined")
                 .header("Authorization", "Token token")
                 .header(
                     "user-agent",
@@ -2335,7 +2335,7 @@ settings:
         undefined_secrets_mock.assert();
 
         assert!(!&result.is_ok());
-        assert!(result.unwrap_err().to_string().contains("Warning: these secrets are undefined: [\"undefined_secret\",\"another_undefined_secret\"]."));
+        assert!(result.unwrap_err().to_string().contains("Warning: these settings are required to be defined: [\"undefined_secret\",\"another_undefined_secret\"]."));
     }
 
     #[test]
@@ -2396,7 +2396,7 @@ settings:
         //  v4/edge-apps/settings?select=type,default_value,optional,title,help_text&app_id=eq.{}&order=title.asc
         let undefined_secrets_mock = mock_server.mock(|when, then| {
             when.method(GET)
-                .path("/v4/edge-apps/secrets/undefined")
+                .path("/v4/edge-apps/settings/undefined")
                 .header("Authorization", "Token token")
                 .header(
                     "user-agent",

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -601,7 +601,8 @@ settings:
     }
 
     #[test]
-    fn test_ensure_manifest_is_valid_when_required_string_field_has_no_default_value_should_fail() {
+    fn test_ensure_manifest_is_valid_when_required_string_field_has_no_default_value_should_succeed(
+    ) {
         let dir = tempdir().unwrap();
         let file_name = "screenly.yml";
         let content = r#"---
@@ -617,8 +618,7 @@ settings:
         write_to_tempfile(&dir, file_name, content);
         let file_path = dir.path().join(file_name);
         let result = EdgeAppManifest::ensure_manifest_is_valid(&file_path);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Setting \"username\" is of type \"string\" and is not optional, it must have a default value"));
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/commands/edge_app_server.rs
+++ b/src/commands/edge_app_server.rs
@@ -53,7 +53,6 @@ pub async fn run_server(
         .and(warp::path("screenly.js"))
         .and(warp::query::<HashMap<String, String>>())
         .and_then({
-            let dir_path = dir_path;
             move |params: HashMap<String, String>| {
                 let dir_path = dir_path.clone();
                 let secrets_clone = secrets_clone.clone();

--- a/src/commands/edge_app_settings.rs
+++ b/src/commands/edge_app_settings.rs
@@ -72,15 +72,6 @@ where
                 setting.title
             )));
         }
-        if setting.type_ == SettingType::String
-            && !setting.optional
-            && setting.default_value.is_none()
-        {
-            return Err(serde::de::Error::custom(format!(
-                "Setting \"{}\" is of type \"string\" and is not optional, it must have a default value",
-                setting.title
-            )));
-        }
     }
 
     settings.sort_by_key(|s| s.title.clone());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -109,7 +109,7 @@ pub enum CommandError {
     InitializationError(String),
     #[error("Asset processing error: {0}")]
     AssetProcessingError(String),
-    #[error("Warning: these secrets are undefined: {0}.")]
+    #[error("Warning: these settings are required to be defined: {0}.")]
     UndefinedSecrets(String),
     #[error("App id is required. Either in manifest or with --app-id.")]
     MissingAppId,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -110,7 +110,7 @@ pub enum CommandError {
     #[error("Asset processing error: {0}")]
     AssetProcessingError(String),
     #[error("Warning: these settings are required to be defined: {0}.")]
-    UndefinedSecrets(String),
+    UndefinedSettings(String),
     #[error("App id is required. Either in manifest or with --app-id.")]
     MissingAppId,
     #[error("App id cannot be empty. Provide it either in manifest or with --app-id.")]


### PR DESCRIPTION
Refs https://phorge.wireload.net/T7672

As we removed constraint from our server, enforsing string setting to have default values, it is also removed from cli.
Also updated url secrets/undefined to settings/undefined as it now returns all undefined settings, not only secrets.

This will require new release, when mentioned changes will be on production.