### PR TITLE
Add Nix support

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,35 @@
+name: Nix
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'src/**'
+      - 'Cargo.toml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'src/**'
+      - 'Cargo.toml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout flake
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v8
+
+      - name: Setup magic-nix-cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build screenly-cli
+        run: nix build .#screenly-cli

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+# Build output for nix
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701058557,
+        "narHash": "sha256-fux7HlrnoNs93MN0kET4AfiYwg/expoasndRCFeDRyk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "070b5cf9f70bc7ef2dfd739a1f7d6c563fe64bd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "Screenly CLI flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      pkgsForSystem = system: (import nixpkgs {
+        inherit system;
+        overlays = [ self.overlays.default ];
+      });
+    in
+    {
+      overlays.default = final: _prev: {
+        screenly-cli = final.rustPlatform.buildRustPackage rec {
+          pname = "screenly-cli";
+          version = "0.2.3";
+
+          src = final.fetchFromGitHub {
+            owner = "screenly";
+            repo = "cli";
+            rev = "refs/tags/v${version}";
+            hash = "sha256-rQK1EYb1xYtcxq0Oj4eY9PCFMoaYinr42W8NkG36ps0=";
+          };
+
+          # This can be removed if/when the next tagged release contains the Cargo.lock.
+          # The patch adds the correct Cargo.lock for v0.2.3 to the sources before the configure
+          # phase.
+          cargoPatches = [
+            (final.fetchpatch {
+              url = "https://gist.githubusercontent.com/jnsgruk/851afc2da1d18ca91e34677c7e72aebb/raw/517e82390f3aa9dbd95793563d7b442186a08940/Cargo.lock";
+              hash = "sha256-Cqc1PHRhgS3zK19bSqpU2v+R3jSlOY6oaLJXpUy6+50=";
+            })
+          ];
+
+          cargoHash = "sha256-TzJ56Wuk77qrxDLL17fYEj4i/YhAS6DRmjoqrzb+5AA=";
+
+          nativeBuildInputs = with final; [ pkg-config perl ];
+
+          buildInputs = with final; [
+            openssl
+          ] ++ final.lib.optionals stdenv.isDarwin [ CoreFoundation Security ];
+
+          meta = {
+            description = "Command Line Interface (CLI) for Screenly.";
+            homepage = "https://github.com/Screenly/cli";
+            license = final.lib.licenses.mit;
+            mainProgram = "screenly";
+            platforms = final.lib.platforms.unix;
+            maintainers = with final.lib.maintainers; [ jnsgruk vpetersson ];
+          };
+        };
+      };
+
+      packages = forAllSystems (system: {
+        inherit (pkgsForSystem system) screenly-cli;
+      });
+
+      devShells = forAllSystems (system: {
+        default = (pkgsForSystem system).mkShell {
+          name = "screenly-cli";
+          NIX_CONFIG = "experimental-features = nix-command flakes";
+          inputsFrom = [ self.packages.${system}.screenly-cli ];
+          shellHook = "exec $SHELL";
+        };
+      });
+    };
+}


### PR DESCRIPTION
## What does this PR do?

Adds a `flake.nix` which enables the following

- Building `screenly-cli` as a nix package (just run `nix build .#screenly-cli` or `nix run .#screenly-cli`)
- A portable development shell will dependencies pre-packaged (`nix develop`)
- A package overlay for use on NixOS machines and other Nix package manager instances.

This PR also adds a workflow that builds that Nix package on pushes to `master` and pull requests.

It would be beneficial in the future if the `Cargo.lock` file was committed to the repository, but I've worked around this in the patch phase of the build.

## GitHub issue or Phabricator ticket number?

None

## How has this been tested?

Tested on a native NixOS machine, and on Ubuntu 22.04 running the nix package manager.

## Checklist before merging

- [x] If have added tests.
- [ ] Is this a new feature? If yes, please write one phrase about this update.
- [ ] I've attached relevant screenshots (if relevant).
