### PR TITLE
Adds: setting global setting

### DIFF
--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -623,7 +623,7 @@ impl EdgeAppCommand {
             &json,
         )?;
         if let Some(arr) = response.as_array() {
-            if let Some(obj) = arr.get(0) {
+            if let Some(obj) = arr.first() {
                 if let Some(revision) = obj["revision"].as_u64() {
                     debug!("New version revision: {}", revision);
                     return Ok(revision as u32);
@@ -649,7 +649,7 @@ impl EdgeAppCommand {
         }
 
         let versions: Vec<EdgeAppVersion> = serde_json::from_value(response)?;
-        if let Some(version) = versions.get(0) {
+        if let Some(version) = versions.first() {
             Ok(version.revision)
         } else {
             Err(CommandError::MissingField)

--- a/src/commands/edge_app_settings.rs
+++ b/src/commands/edge_app_settings.rs
@@ -7,9 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::commands::serde_utils::{
-    deserialize_string_field, serialize_non_empty_string_field,
-};
+use crate::commands::serde_utils::{deserialize_string_field, serialize_non_empty_string_field};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Default, EnumString, Display, EnumIter)]
 pub enum SettingType {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -121,6 +121,8 @@ pub enum CommandError {
     InvalidManifest(String),
     #[error("Edge App Manifest (screenly.yml) doesn't exist under provided path: {0}. Enter a valid command line --path parameter or invoke command in a directory containing Edge App Manifest")]
     MisingManifest(String),
+    #[error("Setting does not exist: {0}.")]
+    SettingDoesNotExist(String),
 }
 
 pub fn get(


### PR DESCRIPTION
Refs https://phorge.wireload.net/T8070

As global setting requires a bit different payload (app_id instead of installation_id) - updated that in set_setting function.
For that - asks server if the setting is global - don't want to rely on the manifest file here.

Next pr will be about setting global secret.