### PR TITLE
Adds: detecting version metadata changes - consider changed as a new …

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -974,12 +974,12 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                         Ok(rev) => match rev {
                             Some(rev) => rev.revision,
                             None => {
-                                println!("Failed to get latest edge app revision.");
+                                println!("Failed to get latest Edge App revision.");
                                 std::process::exit(1);
                             }
                         },
                         Err(e) => {
-                            println!("Failed to get latest edge app revision: {}", e);
+                            println!("Failed to get latest Edge App revision: {}", e);
                             std::process::exit(1);
                         }
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -971,7 +971,13 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
 
                 let revision = if *latest {
                     match edge_app_command.get_latest_revision(&actual_app_id) {
-                        Ok(rev) => rev,
+                        Ok(rev) => match rev {
+                            Some(rev) => rev.revision,
+                            None => {
+                                println!("Failed to get latest edge app revision.");
+                                std::process::exit(1);
+                            }
+                        },
                         Err(e) => {
                             println!("Failed to get latest edge app revision: {}", e);
                             std::process::exit(1);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use reqwest::header::{HeaderMap, InvalidHeaderValue};
 use reqwest::StatusCode;
 
+#[allow(unused_imports)]
 pub use edge_app_settings::SettingType;
 
 pub mod asset;


### PR DESCRIPTION
Refs https://phorge.wireload.net/T8225

Problem before is that just changing icon or description doesn't trigger new version to be created.
We also can't change a version once it is published - it is set in stone.

So now we detect when version metadata is changed and consider it a new version.