### PR TITLE
Feature/installation id manifest

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -934,7 +934,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 {
                     Ok(_installation_id) => _installation_id,
                     Err(e) => {
-                        error!("Error calling promote: {}", e);
+                        error!("Promote failed: {}", e);
                         std::process::exit(1);
                     }
                 };
@@ -943,7 +943,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     match edge_app_command.get_app_id_by_installation(&actual_installation_id) {
                         Ok(id) => id,
                         Err(e) => {
-                            error!("Error calling promote: {}", e);
+                            error!("Promote failed: {}", e);
                             std::process::exit(1);
                         }
                     };

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -24,10 +24,7 @@ pub struct EdgeAppManifest {
         default
     )]
     pub app_id: Option<String>,
-    #[serde(
-        skip_serializing_if = "string_field_is_none_or_empty",
-        default
-    )]
+    #[serde(skip_serializing_if = "string_field_is_none_or_empty", default)]
     pub installation_id: Option<String>,
     #[serde(
         deserialize_with = "deserialize_user_version",
@@ -223,6 +220,7 @@ mod tests {
 
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
+            installation_id: Some("test_installation_id".to_string()),
             user_version: Some("test_version".to_string()),
             description: Some("test_description".to_string()),
             icon: Some("test_icon".to_string()),
@@ -246,6 +244,7 @@ mod tests {
 
         let expected_contents = r#"---
 app_id: test_app
+installation_id: test_installation_id
 user_version: test_version
 description: test_description
 icon: test_icon
@@ -271,6 +270,7 @@ settings:
 
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
+            installation_id: None,
             user_version: Some("test_version".to_string()),
             description: None,
             icon: Some("test_icon".to_string()),
@@ -317,6 +317,7 @@ settings:
 
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
+            installation_id: Some("test_installation_id".to_string()),
             user_version: Some("test_version".to_string()),
             description: Some("".to_string()),
             icon: Some("test_icon".to_string()),
@@ -340,6 +341,7 @@ settings:
 
         let expected_contents = r#"---
 app_id: test_app
+installation_id: test_installation_id
 user_version: test_version
 icon: test_icon
 homepage_url: test_url
@@ -419,6 +421,7 @@ settings:
     fn test_serialize_deserialize_cycle_should_pass_on_valid_struct() {
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
+            installation_id: Some("test_installation_id".to_string()),
             user_version: Some("test_version".to_string()),
             description: Some("test_description".to_string()),
             icon: Some("test_icon".to_string()),
@@ -445,6 +448,7 @@ settings:
     fn test_serialize_deserialize_cycle_with_is_global_setting_should_pass() {
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
+            installation_id: Some("test_installation_id".to_string()),
             user_version: Some("test_version".to_string()),
             description: Some("test_description".to_string()),
             icon: Some("test_icon".to_string()),
@@ -471,6 +475,7 @@ settings:
     fn test_serialize_deserialize_cycle_should_pass_on_valid_struct_missing_optional_fields() {
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
+            installation_id: None,
             user_version: Some("test_version".to_string()),
             description: Some("test_description".to_string()),
             icon: None,
@@ -678,6 +683,7 @@ settings:
 
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
+            installation_id: Some("test_installation_id".to_string()),
             user_version: Some("test_version".to_string()),
             description: Some("test_description".to_string()),
             icon: Some("test_icon".to_string()),
@@ -701,6 +707,7 @@ settings:
 
         let expected_contents = r#"---
 app_id: test_app
+installation_id: test_installation_id
 user_version: test_version
 description: test_description
 icon: test_icon
@@ -724,6 +731,7 @@ settings:
     fn test_prepare_manifest_payload_includes_some_fields() {
         let manifest = EdgeAppManifest {
             app_id: Some("test_app".to_string()),
+            installation_id: Some("test_installation_id".to_string()),
             user_version: Some("test_version".to_string()),
             description: Some("test_description".to_string()),
             icon: Some("test_icon".to_string()),

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -25,6 +25,11 @@ pub struct EdgeAppManifest {
     )]
     pub app_id: Option<String>,
     #[serde(
+        skip_serializing_if = "string_field_is_none_or_empty",
+        default
+    )]
+    pub installation_id: Option<String>,
+    #[serde(
         deserialize_with = "deserialize_user_version",
         skip_serializing_if = "string_field_is_none_or_empty",
         default

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -5,6 +5,8 @@ use crate::commands::CommandError;
 use crate::signature::{generate_signature, sig_to_hex};
 use log::debug;
 use std::collections::{HashMap, HashSet};
+use std::env;
+use std::path::PathBuf;
 
 use crate::commands::ignorer::Ignorer;
 
@@ -64,6 +66,16 @@ fn is_included(entry: &DirEntry, ignore: &Ignorer) -> bool {
     }
 
     return !ignore.is_ignored(entry.path());
+}
+
+pub fn transform_edge_app_path_to_manifest(path: &Option<String>) -> PathBuf {
+    let mut result = match path {
+        Some(path) => PathBuf::from(path),
+        None => env::current_dir().unwrap(),
+    };
+
+    result.push("screenly.yml");
+    result
 }
 
 pub fn collect_paths_for_upload(path: &Path) -> Result<Vec<EdgeAppFile>, CommandError> {
@@ -183,6 +195,7 @@ mod tests {
     fn create_manifest() -> EdgeAppManifest {
         EdgeAppManifest {
             app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            installation_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZBW".to_string()),
             user_version: Some("1".to_string()),
             description: Some("asdf".to_string()),
             icon: Some("asdf".to_string()),
@@ -378,6 +391,7 @@ mod tests {
         // Arrange
         let manifest = EdgeAppManifest {
             app_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            installation_id: Some("01H2QZ6Z8WXWNDC0KQ198XCZBW".to_string()),
             user_version: Some("1".to_string()),
             description: Some("asdf".to_string()),
             icon: Some("asdf".to_string()),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -116,8 +116,6 @@ pub enum CommandError {
     MissingAppId,
     #[error("App id cannot be empty. Provide it either in manifest or with --app-id.")]
     EmptyAppId,
-    #[error("Installation id cannot be empty, when app_id is provided. Provide it with --installation-id or fill both in the manifest.")]
-    EmptyInstallationId,
     #[error("Edge App Revision {0} not found")]
     RevisionNotFound(String),
     #[error("Manifest file validation failed with error: {0}")]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,7 +19,7 @@ pub mod edge_app;
 pub mod edge_app_manifest;
 pub(crate) mod edge_app_server;
 pub(crate) mod edge_app_settings;
-mod edge_app_utils;
+pub mod edge_app_utils;
 mod ignorer;
 pub(crate) mod playlist;
 pub mod screen;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -116,6 +116,8 @@ pub enum CommandError {
     MissingAppId,
     #[error("App id cannot be empty. Provide it either in manifest or with --app-id.")]
     EmptyAppId,
+    #[error("Installation id cannot be empty, when app_id is provided. Provide it with --installation-id or fill both in the manifest.")]
+    EmptyInstallationId,
     #[error("Edge App Revision {0} not found")]
     RevisionNotFound(String),
     #[error("Manifest file validation failed with error: {0}")]


### PR DESCRIPTION
Bringing installation_id back, cause now we could have multiple installation in the UI.

For compatability with old yamls without installation_id, cli, when needed, will request(or create) and save installation_id using deprecated name 'Edge app cli installation'.
So eventually yaml file must have installation_id to work properly.

Other changes
- Installation of an app moved from upload to edge app create command.
- For some commands now installation_id is required either by passing as argument or in the manifest.
  - Promote command(to check undefined settings)
  - All settings commands
  - Secret set command