### PR TITLE
Adds: release 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3 as builder
 
 WORKDIR /usr/src/screenly-cli
 RUN apk add --no-cache wget tar
-ARG RELEASE=v0.2.5
+ARG RELEASE=v0.2.6
 RUN wget "https://github.com/Screenly/cli/releases/download/$RELEASE/screenly-cli-x86_64-unknown-linux-musl.tar.gz"
 RUN tar xfz screenly-cli-x86_64-unknown-linux-musl.tar.gz
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   cli_version:
     description: "Screenly CLI version."
-    default: "v0.2.5"
+    default: "v0.2.6"
 outputs:
   cli_commands_response:
     description: "The response from the Screenly CLI command(s)."


### PR DESCRIPTION
Releasing 0.2.6 version

Changes:

 - Delete missing settings
 - Entrypoint now pushed to installation instead of version
 - Name of the installation from cli is now equal to app name instead of generic name.