### PR TITLE
Edits: 'edge-app run' open in browser

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,9 @@ jobs:
   lint:
     name: Lint code base
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: 'read'
+      pull-requests: 'read'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
-      pull-requests: 'read'
+      checks: 'write'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -391,6 +391,28 @@ impl EdgeAppCommand {
                 address_shared.lock().unwrap().as_ref().unwrap()
             );
 
+            #[cfg(target_os = "macos")]
+            {
+                let _ = std::process::Command::new("open")
+                    .arg(format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
+                    .output();
+            }
+
+            #[cfg(target_os = "linux")]
+            {
+                let _ = std::process::Command::new("xdg-open")
+                    .arg(format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
+                    .output();
+            }
+
+            #[cfg(target_os = "windows")]
+            {
+                let _ = std::process::Command::new("cmd")
+                    .arg("/C")
+                    .arg(format!("start {}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
+                    .output();
+            }
+
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
             }

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -391,32 +391,42 @@ impl EdgeAppCommand {
                 address_shared.lock().unwrap().as_ref().unwrap()
             );
 
-            #[cfg(target_os = "macos")]
-            {
-                let _ = std::process::Command::new("open")
-                    .arg(format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
-                    .output();
-            }
-
-            #[cfg(target_os = "linux")]
-            {
-                let _ = std::process::Command::new("xdg-open")
-                    .arg(format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
-                    .output();
-            }
-
-            #[cfg(target_os = "windows")]
-            {
-                let _ = std::process::Command::new("cmd")
-                    .arg("/C")
-                    .arg(format!("start {}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
-                    .output();
+            if let Err(e) = self.open_browser(
+                &format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()),
+            ) {
+                eprintln!("{}", e);
             }
 
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
             }
         });
+
+        Ok(())
+    }
+
+    fn open_browser(&self, address: &str) -> Result<(), CommandError> {
+        let command = match std::env::consts::OS {
+            "macos" => "open",
+            "windows" => "start",
+            "linux" => "xdg-open",
+            _ => {
+                return Err(CommandError::OpenBrowserError(
+                    "Unsupported OS to open browser".to_string()
+                ))
+            }
+        };
+
+        let output = std::process::Command::new(command)
+            .arg(address)
+            .output()
+            .expect("Failed to open browser");
+
+        if !output.status.success() {
+            return Err(CommandError::OpenBrowserError(
+                format!("Failed to open browser: {}", str::from_utf8(&output.stderr).unwrap())
+            ));
+        }
 
         Ok(())
     }

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -391,9 +391,10 @@ impl EdgeAppCommand {
                 address_shared.lock().unwrap().as_ref().unwrap()
             );
 
-            if let Err(e) = self.open_browser(
-                &format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()),
-            ) {
+            if let Err(e) = self.open_browser(&format!(
+                "{}/index.html",
+                address_shared.lock().unwrap().as_ref().unwrap()
+            )) {
                 eprintln!("{}", e);
             }
 
@@ -412,7 +413,7 @@ impl EdgeAppCommand {
             "linux" => "xdg-open",
             _ => {
                 return Err(CommandError::OpenBrowserError(
-                    "Unsupported OS to open browser".to_string()
+                    "Unsupported OS to open browser".to_string(),
                 ))
             }
         };
@@ -423,9 +424,10 @@ impl EdgeAppCommand {
             .expect("Failed to open browser");
 
         if !output.status.success() {
-            return Err(CommandError::OpenBrowserError(
-                format!("Failed to open browser: {}", str::from_utf8(&output.stderr).unwrap())
-            ));
+            return Err(CommandError::OpenBrowserError(format!(
+                "Failed to open browser: {}",
+                str::from_utf8(&output.stderr).unwrap()
+            )));
         }
 
         Ok(())

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -391,42 +391,32 @@ impl EdgeAppCommand {
                 address_shared.lock().unwrap().as_ref().unwrap()
             );
 
-            if let Err(e) = self.open_browser(
-                &format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()),
-            ) {
-                eprintln!("{}", e);
+            #[cfg(target_os = "macos")]
+            {
+                let _ = std::process::Command::new("open")
+                    .arg(format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
+                    .output();
+            }
+
+            #[cfg(target_os = "linux")]
+            {
+                let _ = std::process::Command::new("xdg-open")
+                    .arg(format!("{}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
+                    .output();
+            }
+
+            #[cfg(target_os = "windows")]
+            {
+                let _ = std::process::Command::new("cmd")
+                    .arg("/C")
+                    .arg(format!("start {}/index.html", address_shared.lock().unwrap().as_ref().unwrap()))
+                    .output();
             }
 
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
             }
         });
-
-        Ok(())
-    }
-
-    fn open_browser(&self, address: &str) -> Result<(), CommandError> {
-        let command = match std::env::consts::OS {
-            "macos" => "open",
-            "windows" => "start",
-            "linux" => "xdg-open",
-            _ => {
-                return Err(CommandError::OpenBrowserError(
-                    "Unsupported OS to open browser".to_string()
-                ))
-            }
-        };
-
-        let output = std::process::Command::new(command)
-            .arg(address)
-            .output()
-            .expect("Failed to open browser");
-
-        if !output.status.success() {
-            return Err(CommandError::OpenBrowserError(
-                format!("Failed to open browser: {}", str::from_utf8(&output.stderr).unwrap())
-            ));
-        }
 
         Ok(())
     }

--- a/src/commands/edge_app_server.rs
+++ b/src/commands/edge_app_server.rs
@@ -80,6 +80,7 @@ pub async fn run_server(
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct WarpError(#[allow(dead_code)] anyhow::Error);
 
 impl Reject for WarpError {}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -126,6 +126,8 @@ pub enum CommandError {
     SettingDoesNotExist(String),
     #[error("Wrong setting name: {0}.")]
     WrongSettingName(String),
+    #[error("Failed to open browser")]
+    OpenBrowserError(String),
 }
 
 pub fn get(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -126,8 +126,6 @@ pub enum CommandError {
     SettingDoesNotExist(String),
     #[error("Wrong setting name: {0}.")]
     WrongSettingName(String),
-    #[error("Failed to open browser")]
-    OpenBrowserError(String),
 }
 
 pub fn get(


### PR DESCRIPTION
Ticket: https://phorge.wireload.net/T8681

Edits:
- `screenly edge-app run` opens the URL in browser

It is tested only on Linux.