### PR TITLE
Fix: screenly.secrets merged into screenly.settings in 'screenly edge-app run'

### DIFF
--- a/src/commands/edge_app_server.rs
+++ b/src/commands/edge_app_server.rs
@@ -146,13 +146,13 @@ fn format_js(data: MockData, secrets: &[(String, Value)]) -> String {
         .map(|(k, v)| (k, Value::Str(v)))
         .collect();
 
+    settings.extend(secrets.iter().map(|(k, v)| (k.clone(), v.clone())));
     settings.sort_by_key(|a| a.0.clone());
 
     format!(
-        "var screenly = {{\n{metadata},\n{settings},\n{secrets},\n{cors_proxy}\n}};",
+        "var screenly = {{\n{metadata},\n{settings},\n{cors_proxy}\n}};",
         metadata = format_section("metadata", &hashmap_from_metadata(&data.metadata)),
         settings = format_section("settings", &settings),
-        secrets = format_section("secrets", secrets),
         cors_proxy = "    cors_proxy_url: \"http://127.0.0.1:8080\""
     )
 }
@@ -270,11 +270,9 @@ settings:
     },
     settings: {
         "enable_analytics": "true",
+        "key": "value",
         "override_timezone": "",
         "tag_manager_id": ""
-    },
-    secrets: {
-        "key": "value"
     },
     cors_proxy_url: "http://127.0.0.1:8080"
 };"#;


### PR DESCRIPTION
Ticket: https://phorge.wireload.net/T8625

Edits:
- secrets are merged into settings in Edge App emulator