### PR TITLE
Feature/instance commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -432,7 +432,6 @@ pub enum EdgeAppSecretsCommands {
     },
 }
 
-
 #[derive(Subcommand, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EdgeAppInstanceCommands {
     /// Lists Edge App instances.
@@ -454,7 +453,7 @@ pub enum EdgeAppInstanceCommands {
         /// Edge app id. If not specified CLI will use the id from the manifest.
         #[arg(short, long)]
         app_id: Option<String>,
-        
+
         /// Name of the Edge App instance.
         #[arg(short, long)]
         name: Option<String>,
@@ -488,7 +487,6 @@ pub enum EdgeAppInstanceCommands {
         path: Option<String>,
     },
 }
-
 
 pub fn handle_command_execution_result<T: Formatter>(
     result: anyhow::Result<T, CommandError>,
@@ -1156,11 +1154,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             }
         }
         EdgeAppCommands::Instance(command) => match command {
-            EdgeAppInstanceCommands::List {
-                app_id,
-                path,
-                json,
-            } => {
+            EdgeAppInstanceCommands::List { app_id, path, json } => {
                 let actual_app_id = match edge_app_command.get_actual_app_id(app_id, path) {
                     Ok(id) => id,
                     Err(e) => {
@@ -1181,8 +1175,12 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                         std::process::exit(1);
                     }
                 };
-                match edge_app_command.create_instance(&actual_app_id, "temp") {
-                    Ok((_some_id)) => {
+                let new_name = match name {
+                    Some(name) => name,
+                    None => "Edge App instance created by Screenly CLI",
+                };
+                match edge_app_command.create_instance(&actual_app_id, new_name) {
+                    Ok(_some_id) => {
                         println!("Edge app instance successfully created.");
                     }
                     Err(e) => {
@@ -1236,7 +1234,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     }
                 }
             }
-        }
+        },
     }
 }
 

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -2,7 +2,7 @@ use crate::authentication::Authentication;
 use crate::commands;
 use crate::commands::edge_app_manifest::EdgeAppManifest;
 use crate::commands::edge_app_settings::{deserialize_settings_from_array, Setting, SettingType};
-use crate::commands::{CommandError, EdgeAppSecrets, EdgeAppSettings, EdgeAppVersions, EdgeApps, EdgeAppInstances};
+use crate::commands::{CommandError, EdgeAppInstances, EdgeAppSecrets, EdgeAppSettings, EdgeApps};
 use indicatif::ProgressBar;
 use log::debug;
 use std::collections::HashMap;
@@ -341,7 +341,7 @@ impl EdgeAppCommand {
         if channels.is_empty() {
             return Err(CommandError::MissingField);
         }
-        if &channels[0].channel != channel || channels[0].app_revision != revision {
+        if channels[0].channel != channel || channels[0].app_revision != revision {
             return Err(CommandError::MissingField);
         }
 
@@ -481,12 +481,10 @@ impl EdgeAppCommand {
     fn requires_upload(&self, changed_files: &FileChanges) -> bool {
         changed_files.has_changes()
     }
-
 }
 
 // Edge app settings commands
 impl EdgeAppCommand {
-
     pub fn list_settings(&self, installation_id: &str) -> Result<EdgeAppSettings, CommandError> {
         let app_id = self.get_app_id_by_installation(installation_id)?;
         let response = commands::get(
@@ -657,12 +655,10 @@ impl EdgeAppCommand {
 
         Ok(())
     }
-
 }
 
 // Edge app instance commands
 impl EdgeAppCommand {
-        
     pub fn list_instances(&self, app_id: &str) -> Result<EdgeAppInstances, CommandError> {
         let response = commands::get(
             &self.authentication,
@@ -677,11 +673,7 @@ impl EdgeAppCommand {
         Ok(instances)
     }
 
-    pub fn create_instance(
-        &self,
-        app_id: &str,
-        name: &str,
-    ) -> Result<String, CommandError> {
+    pub fn create_instance(&self, app_id: &str, name: &str) -> Result<String, CommandError> {
         let installation_id = self.install_edge_app(app_id, name, None)?;
         // let installation_id =
         // self.install_edge_app(&app_id, name, Some("index.html".to_string()))?;
@@ -703,7 +695,7 @@ impl EdgeAppCommand {
         installation_id: &str,
         name: &Option<String>,
     ) -> Result<(), CommandError> {
-        let mut payload = json!({
+        let payload = json!({
             "name": name,
         });
 
@@ -719,7 +711,6 @@ impl EdgeAppCommand {
 
         Ok(())
     }
-
 }
 
 impl EdgeAppCommand {
@@ -1441,10 +1432,7 @@ mod tests {
         let data = fs::read_to_string(tmp_dir.path().join("screenly.yml")).unwrap();
         let manifest: EdgeAppManifest = serde_yaml::from_str(&data).unwrap();
         assert_eq!(manifest.app_id, Some("test-id".to_owned()));
-        assert_eq!(
-            manifest.installation_id,
-            None
-        );
+        assert_eq!(manifest.installation_id, None);
         assert_eq!(
             manifest.settings,
             vec![
@@ -1554,10 +1542,7 @@ mod tests {
         let data = fs::read_to_string(tmp_dir.path().join("screenly.yml")).unwrap();
         let manifest: EdgeAppManifest = serde_yaml::from_str(&data).unwrap();
         assert_eq!(manifest.app_id, Some("test-id".to_owned()));
-        assert_eq!(
-            manifest.installation_id,
-            None
-        );
+        assert_eq!(manifest.installation_id, None);
 
         assert!(result.is_ok());
     }
@@ -4002,7 +3987,7 @@ settings:
     }
 
     #[test]
-    fn test_instance_list_should_list_instances(){
+    fn test_instance_list_should_list_instances() {
         let mock_server = MockServer::start();
 
         let config = Config::new(mock_server.base_url());
@@ -4061,7 +4046,7 @@ settings:
     }
 
     #[test]
-    fn test_create_instance_should_create_instance(){
+    fn test_create_instance_should_create_instance() {
         let mock_server = MockServer::start();
 
         let config = Config::new(mock_server.base_url());
@@ -4085,16 +4070,17 @@ settings:
                     "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
                     "name": "Edge app cli installation",
                 }));
-            then.status(201).json_body(json!([{"id": "01H2QZ6Z8WXWNDC0KQ198XCZEB"}]));
+            then.status(201)
+                .json_body(json!([{"id": "01H2QZ6Z8WXWNDC0KQ198XCZEB"}]));
         });
-        
-        let result = command.create_instance(&manifest.app_id.unwrap(), "Edge app cli installation");
+
+        let result =
+            command.create_instance(&manifest.app_id.unwrap(), "Edge app cli installation");
 
         create_instance_mock.assert();
         assert!(result.is_ok());
 
         assert_eq!(result.unwrap(), "01H2QZ6Z8WXWNDC0KQ198XCZEB");
-
     }
 
     #[test]
@@ -4122,10 +4108,14 @@ settings:
                 .json_body(json!({
                     "name": "Edge app cli installation 2",
                 }));
-            then.status(200).json_body(json!([{"id": "01H2QZ6Z8WXWNDC0KQ198XCZEB"}]));
+            then.status(200)
+                .json_body(json!([{"id": "01H2QZ6Z8WXWNDC0KQ198XCZEB"}]));
         });
 
-        let result = command.update_instance("01H2QZ6Z8WXWNDC0KQ198XCZEB", &Some("Edge app cli installation 2".to_string()));
+        let result = command.update_instance(
+            "01H2QZ6Z8WXWNDC0KQ198XCZEB",
+            &Some("Edge app cli installation 2".to_string()),
+        );
 
         update_instance_mock.assert();
         assert!(result.is_ok());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -438,6 +438,45 @@ impl Formatter for EdgeAppSecrets {
 }
 
 #[derive(Debug)]
+pub struct EdgeAppInstances {
+    pub value: serde_json::Value,
+}
+
+impl EdgeAppInstances {
+    pub fn new(value: serde_json::Value) -> Self {
+        Self { value }
+    }
+}
+
+impl FormatterValue for EdgeAppInstances {
+    fn value(&self) -> &serde_json::Value {
+        &self.value
+    }
+}
+
+impl Formatter for EdgeAppInstances {
+    fn format(&self, output_type: OutputType) -> String {
+        format_value(
+            output_type,
+            vec![
+                "Id",
+                "Name",
+            ],
+            vec![
+                "id",
+                "name",
+            ],
+            self,
+            Some(
+                |field_name: &str, field_value: &serde_json::Value| -> Cell {
+                    Cell::new(field_value.as_str().unwrap_or_default())
+                },
+            ),
+        )
+    }
+}
+
+#[derive(Debug)]
 pub struct Assets {
     pub value: serde_json::Value,
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -110,8 +110,6 @@ pub enum CommandError {
     InitializationError(String),
     #[error("Asset processing error: {0}")]
     AssetProcessingError(String),
-    #[error("Warning: these settings are required to be defined: {0}.")]
-    UndefinedSettings(String),
     #[error("App id is required. Either in manifest or with --app-id.")]
     MissingAppId,
     #[error("App id cannot be empty. Provide it either in manifest or with --app-id.")]
@@ -298,56 +296,6 @@ impl Formatter for EdgeApps {
 }
 
 #[derive(Debug)]
-pub struct EdgeAppVersions {
-    pub value: serde_json::Value,
-}
-
-impl EdgeAppVersions {
-    pub fn new(value: serde_json::Value) -> Self {
-        Self { value }
-    }
-}
-
-impl FormatterValue for EdgeAppVersions {
-    fn value(&self) -> &serde_json::Value {
-        &self.value
-    }
-}
-impl Formatter for EdgeAppVersions {
-    fn format(&self, output_type: OutputType) -> String {
-        format_value(
-            output_type,
-            vec!["Revision", "Description", "Published", "Channels"],
-            vec!["revision", "description", "published", "edge_app_channels"],
-            self,
-            Some(|field_name: &str, field_value: &serde_json::Value| {
-                if field_name.eq("revision") {
-                    let version = field_value.as_u64().unwrap_or(0);
-                    let str_version = version.to_string();
-                    Cell::new(if version > 0 { &str_version } else { "N/A" })
-                } else if field_name.eq("published") {
-                    let published = field_value.as_bool().unwrap_or(false);
-                    Cell::new(if published { "✅" } else { "❌" })
-                } else if field_name.eq("edge_app_channels") {
-                    // list of maps to string with comma separator
-                    // [{"channel":"stable"},{"channel":"beta"}] -> "stable, beta"
-                    let channels = field_value
-                        .as_array()
-                        .unwrap_or(&vec![])
-                        .iter()
-                        .map(|channel| channel["channel"].as_str().unwrap_or(""))
-                        .collect::<Vec<&str>>()
-                        .join(", ");
-                    Cell::new(channels.as_str())
-                } else {
-                    Cell::new(field_value.as_str().unwrap_or("N/A"))
-                }
-            }),
-        )
-    }
-}
-
-#[derive(Debug)]
 pub struct EdgeAppSettings {
     pub value: serde_json::Value,
 }
@@ -458,17 +406,11 @@ impl Formatter for EdgeAppInstances {
     fn format(&self, output_type: OutputType) -> String {
         format_value(
             output_type,
-            vec![
-                "Id",
-                "Name",
-            ],
-            vec![
-                "id",
-                "name",
-            ],
+            vec!["Id", "Name"],
+            vec!["id", "name"],
             self,
             Some(
-                |field_name: &str, field_value: &serde_json::Value| -> Cell {
+                |_field_name: &str, field_value: &serde_json::Value| -> Cell {
                     Cell::new(field_value.as_str().unwrap_or_default())
                 },
             ),
@@ -632,46 +574,46 @@ impl Formatter for PlaylistItems {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
 
-    #[test]
-    fn test_edge_app_versions_formatter_format_output_properly() {
-        let data = r#"[{
-            "edge_app_channels": [
-                {
-                    "channel": "stable"
-                },
-                {
-                    "channel": "candidate"
-                }
-            ],
-            "revision": 1,
-            "user_version": "1.0.0",
-            "description": "Initial release",
-            "published": true
-        },
-        {
-            "edge_app_channels": [],
-            "revision": 2,
-            "user_version": "1.0.1",
-            "description": "Bug fixes",
-            "published": true
-        }]"#;
-        let edge_app_versions = EdgeAppVersions::new(serde_json::from_str(data).unwrap());
-
-        let output = edge_app_versions.format(OutputType::HumanReadable);
-        assert_eq!(
-            output,
-            r#"+----------+-----------------+-----------+-------------------+
-| Revision | Description     | Published | Channels          |
-+----------+-----------------+-----------+-------------------+
-| 1        | Initial release | ✅        | stable, candidate |
-+----------+-----------------+-----------+-------------------+
-| 2        | Bug fixes       | ✅        |                   |
-+----------+-----------------+-----------+-------------------+
-"#
-        );
-    }
-}
+//     #[test]
+//     fn test_edge_app_versions_formatter_format_output_properly() {
+//         let data = r#"[{
+//             "edge_app_channels": [
+//                 {
+//                     "channel": "stable"
+//                 },
+//                 {
+//                     "channel": "candidate"
+//                 }
+//             ],
+//             "revision": 1,
+//             "user_version": "1.0.0",
+//             "description": "Initial release",
+//             "published": true
+//         },
+//         {
+//             "edge_app_channels": [],
+//             "revision": 2,
+//             "user_version": "1.0.1",
+//             "description": "Bug fixes",
+//             "published": true
+//         }]"#;
+//         let edge_app_versions = EdgeAppVersions::new(serde_json::from_str(data).unwrap());
+//
+//         let output = edge_app_versions.format(OutputType::HumanReadable);
+//         assert_eq!(
+//             output,
+//             r#"+----------+-----------------+-----------+-------------------+
+// | Revision | Description     | Published | Channels          |
+// +----------+-----------------+-----------+-------------------+
+// | 1        | Initial release | ✅        | stable, candidate |
+// +----------+-----------------+-----------+-------------------+
+// | 2        | Bug fixes       | ✅        |                   |
+// +----------+-----------------+-----------+-------------------+
+// "#
+//         );
+//     }
+// }


### PR DESCRIPTION
Updating commands, based on this task https://phorge.wireload.net/T8669

Actual changes:

New instance commands:
`screenly edge-app instance list/create/update/delete`

version commands removed(always use latest version after upload)
promote version is moved inside an upload command, which is renamed to deploy.
So basically upload will create a new version and promote it afterwards.