### PR TITLE
Feature/instance commands instance manifest

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,9 @@ use crate::authentication::{verify_and_store_token, Authentication, Authenticati
 use crate::commands;
 use crate::commands::edge_app_manifest::EdgeAppManifest;
 use crate::commands::edge_app_server::MOCK_DATA_FILENAME;
-use crate::commands::edge_app_utils::transform_edge_app_path_to_manifest;
+use crate::commands::edge_app_utils::{
+    transform_edge_app_path_to_manifest, transform_instance_path_to_instance_manifest,
+};
 use crate::commands::playlist::PlaylistCommand;
 use crate::commands::{CommandError, Formatter, OutputType, PlaylistFile};
 const DEFAULT_ASSET_DURATION: u32 = 15;
@@ -1093,7 +1095,13 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                     Some(name) => name,
                     None => "Edge App instance created by Screenly CLI",
                 };
-                match edge_app_command.create_instance(&actual_app_id, new_name) {
+
+                let instance_manifest_path = transform_instance_path_to_instance_manifest(path);
+                match edge_app_command.create_instance(
+                    &instance_manifest_path,
+                    &actual_app_id,
+                    new_name,
+                ) {
                     Ok(_some_id) => {
                         println!("Edge app instance successfully created.");
                     }

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -79,6 +79,16 @@ pub fn transform_edge_app_path_to_manifest(path: &Option<String>) -> PathBuf {
     result
 }
 
+pub fn transform_instance_path_to_instance_manifest(path: &Option<String>) -> PathBuf {
+    let mut result = match path {
+        Some(path) => PathBuf::from(path),
+        None => env::current_dir().unwrap(),
+    };
+
+    result.push("instance.yml");
+    result
+}
+
 pub fn collect_paths_for_upload(path: &Path) -> Result<Vec<EdgeAppFile>, CommandError> {
     let mut files = Vec::new();
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -127,6 +127,8 @@ pub enum CommandError {
     WrongSettingName(String),
     #[error("Failed to open browser")]
     OpenBrowserError(String),
+    #[error("Instance already exists")]
+    InstanceAlreadyExists,
 }
 
 pub fn get(


### PR DESCRIPTION
Updates instance create command to work with instance manifest.
Uncommented list as it just works. update/delete test also uncommented as they work with arbitrary instance_id

Though have some open questions we need to discuss:

### Create command

Now behaviour is - we only create instance if there is no instance.yml present.
Though we could support --force to re-create instance and re-write instance.yml or --new to create new instance w/o touch instance.yml

### Update command.
We have instance.yml and not sure what to do if we update name or entrypoint in the yml file - when and how should we update that instance then?
Also update command by itself could rename the instance(or change the entrypoint I guess if implemented) - so question is - should we also update instance.yml if update is called directly?

### Delete command
Similar question is here - though I believe if we delete instance that is in the instance.yml - we just delete the file.
Should we prompt user with an instance name to confirm deletion?

