### PR TITLE
Added: trigger Developer Portal deploy workflow on docs changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,9 @@ jobs:
           fi
 
       - name: Trigger Developer Portal deploy workflow
-        if: needs.check_files_changed.outputs.docs_command_line_help == 'false'
+        if: (needs.check_files_changed.outputs.docs_command_line_help == 'true') && 
+            (github.event_name == 'push') && 
+            (github.ref == 'refs/heads/master')
         run: |
           curl -L \
             -X POST \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,24 @@ on:
     - master
 
 jobs:
+  check_files_changed:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      contents: 'read'
+      pull-requests: 'read'
+    outputs:
+      docs_command_line_help: ${{ steps.filter.outputs.docs_command_line_help }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          list-files: shell
+          filters: |
+            docs_command_line_help:
+              - modified: 'docs/CommandLineHelp.md'
+
   docs-help-md:
     permissions:
       contents: write
@@ -40,6 +58,7 @@ jobs:
           fi
 
       - name: Trigger Developer Portal deploy workflow
+        if: steps.check_files_changed.outputs.docs_command_line_help == 'false'
         run: |
           curl -L \
             -X POST \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,8 @@ jobs:
               - modified: 'docs/CommandLineHelp.md'
 
   docs-help-md:
+    needs:
+      - check_files_changed
     permissions:
       contents: write
     runs-on: ubuntu-22.04
@@ -58,7 +60,7 @@ jobs:
           fi
 
       - name: Trigger Developer Portal deploy workflow
-        if: steps.check_files_changed.outputs.docs_command_line_help == 'false'
+        if: needs.check_files_changed.outputs.docs_command_line_help == 'false'
         run: |
           curl -L \
             -X POST \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,3 +38,13 @@ jobs:
           else
             echo "Documentation is up to date."
           fi
+
+      - name: Trigger Developer Portal deploy workflow
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.DEVELOPER_PORTAL_REPO_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d '{"event_type": "deploy"}' \
+            https://api.github.com/repos/Screenly/developer-portal/dispatches


### PR DESCRIPTION
Edits
- Developer Portal deploy workflow will be triggered on push to master if `docs/CommandLineHelp.md` changed 

Example: https://github.com/Screenly/developer-portal/actions/runs/9892684905