### PR TITLE
Updates: instances commands with new changes. Updated transform insts…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "simple_logger",
  "strum",
  "strum_macros",
+ "temp-env",
  "tempfile",
  "term",
  "thiserror",
@@ -2789,6 +2790,15 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ walkdir = "2.3.3"
 glob = "0.3.1"
 futures = "0.3.28"
 serde_with = "3.8.3"
+temp-env = "0.3.6"
 
 [dev-dependencies]
 httpmock = "0.6"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -129,6 +129,10 @@ pub enum CommandError {
     OpenBrowserError(String),
     #[error("Instance already exists")]
     InstanceAlreadyExists,
+    #[error("Env var INSTANCE_FILENAME must hold only file name, not a path. {0}")]
+    InstanceFilenameError(String),
+    #[error("Path is not a directory: {0}")]
+    PathIsNotDirError(String),
 }
 
 pub fn get(


### PR DESCRIPTION
Handles transform path to instance manifest properly. 
It validates folder and filename properly. Filename could be overrided with an env var INSTANCE_FILE_NAME.

Adds dep test-env to easily test with env vars in parallel environment.

Updates:

Update command - now it only checks if instance file was updated(with name only currently, should be updated with entrypoint when implemented on backend) and syncs with server. Arg --name support removed.

Delete command - deletes file after instance was deleted.