### PR TITLE
Feature/update entrypoint

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -870,11 +870,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             app_id,
             delete_missing_settings,
         } => {
-            match edge_app_command.deploy(
-                transform_edge_app_path_to_manifest(path).as_path(),
-                app_id.clone(),
-                *delete_missing_settings,
-            ) {
+            match edge_app_command.deploy(path.clone(), app_id.clone(), *delete_missing_settings) {
                 Ok(revision) => {
                     println!(
                         "Edge app successfully deployed. Revision: {revision}.",
@@ -903,20 +899,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 );
             }
             EdgeAppSettingsCommands::Set { setting_pair, path } => {
-                let actual_installation_id =
-                    match edge_app_command.get_installation_id(path.clone()) {
-                        Ok(_installation_id) => _installation_id,
-                        Err(e) => {
-                            error!("Error calling set setting: {}", e);
-                            std::process::exit(1);
-                        }
-                    };
-
-                match edge_app_command.set_setting(
-                    &actual_installation_id,
-                    &setting_pair.0,
-                    &setting_pair.1,
-                ) {
+                match edge_app_command.set_setting(path.clone(), &setting_pair.0, &setting_pair.1) {
                     Ok(()) => {
                         println!("Edge app setting successfully set.");
                     }
@@ -1124,27 +1107,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 }
             }
             EdgeAppInstanceCommands::Update { path } => {
-                let actual_installation_id =
-                    match edge_app_command.get_installation_id(path.clone()) {
-                        Ok(_installation_id) => _installation_id,
-                        Err(e) => {
-                            error!("Error calling update setting: {}", e);
-                            std::process::exit(1);
-                        }
-                    };
-
-                let instance_manifest_path =
-                    match transform_instance_path_to_instance_manifest(path) {
-                        Ok(path) => path,
-                        Err(e) => {
-                            eprintln!("Failed to create edge app instance: {e}.");
-                            std::process::exit(1);
-                        }
-                    };
-
-                match edge_app_command
-                    .update_instance(&actual_installation_id, instance_manifest_path.as_path())
-                {
+                match edge_app_command.update_instance(path.clone()) {
                     Ok(()) => {
                         println!("Edge app instance successfully updated.");
                     }

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -237,15 +237,15 @@ where
                  uri,
              }| {
                 match (entrypoint_type, uri) {
-                    (EntrypointType::RemoteLocal, None) => Err(serde::de::Error::custom(
-                        "URI is required for remote-local type",
+                    (EntrypointType::RemoteGlobal, None) => Err(serde::de::Error::custom(
+                        "URI is required for remote-global type",
                     )),
-                    (EntrypointType::RemoteLocal, Some(uri)) => Ok(Entrypoint {
+                    (EntrypointType::RemoteGlobal, Some(uri)) => Ok(Entrypoint {
                         entrypoint_type,
                         uri: Some(uri),
                     }),
-                    (EntrypointType::RemoteGlobal, Some(_)) => Err(serde::de::Error::custom(
-                        "URI should not be provided for remote-global type",
+                    (EntrypointType::RemoteLocal, Some(_)) => Err(serde::de::Error::custom(
+                        "URI should not be provided for remote-local type",
                     )),
                     (EntrypointType::File, Some(_)) => Err(serde::de::Error::custom(
                         "URI should not be provided for file type",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -114,7 +114,7 @@ pub enum CommandError {
     AssetProcessingError(String),
     #[error("App id is required. Either in manifest or with --app-id.")]
     MissingAppId,
-    #[error("App id cannot be empty. Provide it either in manifest or with --app-id.")]
+    #[error("App id cannot be empty. Provide it either in manifest.")]
     EmptyAppId,
     #[error("Edge App Revision {0} not found")]
     RevisionNotFound(String),


### PR DESCRIPTION
Decided to have entrypoint as a settings(either global if it is RemoteGlobal, or non global if it is RemoteLocal)

In the end there will be a setting defined for both options above: screenly_entrypoint.
For File type no need to define it as we can default to index.html on the device.

When deploy happens now:
 - Setting for entrypoint is created if it doesn't exist(or requested to be deleted, same as for usual settings)
 - If entrypoint is global, value is also taken from yml and pushed/patched to server

If it is local, value update is happening on the instance update command instead.

Also fixed error in validation of RemoteGlobal and RemoteLocal.