### PR TITLE
Rename: auth setting prepended with screenly_

### DIFF
--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -684,11 +684,11 @@ mod tests {
         assert!(changes
             .creates
             .iter()
-            .any(|s| s.name == "basic_auth_username" && !s.is_global));
+            .any(|s| s.name == "screenly_basic_auth_username" && !s.is_global));
         assert!(changes
             .creates
             .iter()
-            .any(|s| s.name == "basic_auth_password" && !s.is_global));
+            .any(|s| s.name == "screenly_basic_auth_password" && !s.is_global));
     }
 
     #[test]
@@ -709,7 +709,7 @@ mod tests {
         assert!(result.is_ok());
         let changes = result.unwrap();
         assert_eq!(changes.creates.len(), 1);
-        assert_eq!(changes.creates[0].name, "bearer_token");
+        assert_eq!(changes.creates[0].name, "screenly_bearer_token");
         assert!(!changes.creates[0].is_global);
     }
 
@@ -727,14 +727,14 @@ mod tests {
             Setting::new(
                 SettingType::String,
                 "Username",
-                "basic_auth_username",
+                "screenly_basic_auth_username",
                 "Basic auth username",
                 false,
             ),
             Setting::new(
                 SettingType::Secret,
                 "Password",
-                "basic_auth_password",
+                "screenly_basic_auth_password",
                 "Basic auth password",
                 false,
             ),
@@ -747,17 +747,17 @@ mod tests {
         assert!(result.is_ok());
         let changes = result.unwrap();
         assert_eq!(changes.creates.len(), 1);
-        assert_eq!(changes.creates[0].name, "bearer_token");
+        assert_eq!(changes.creates[0].name, "screenly_bearer_token");
         assert!(!changes.creates[0].is_global);
         assert_eq!(changes.deleted.len(), 2);
         assert!(changes
             .deleted
             .iter()
-            .any(|s| s.name == "basic_auth_username"));
+            .any(|s| s.name == "screenly_basic_auth_username"));
         assert!(changes
             .deleted
             .iter()
-            .any(|s| s.name == "basic_auth_password"));
+            .any(|s| s.name == "screenly_basic_auth_password"));
     }
 
     #[test]
@@ -773,7 +773,7 @@ mod tests {
         remote_settings.push(Setting::new(
             SettingType::String,
             "Token",
-            "bearer_token",
+            "screenly_bearer_token",
             "Bearer token",
             false,
         ));
@@ -788,13 +788,13 @@ mod tests {
         assert!(changes
             .creates
             .iter()
-            .any(|s| s.name == "basic_auth_username" && !s.is_global));
+            .any(|s| s.name == "screenly_basic_auth_username" && !s.is_global));
         assert!(changes
             .creates
             .iter()
-            .any(|s| s.name == "basic_auth_password" && !s.is_global));
+            .any(|s| s.name == "screenly_basic_auth_password" && !s.is_global));
         assert_eq!(changes.deleted.len(), 1);
-        assert_eq!(changes.deleted[0].name, "bearer_token");
+        assert_eq!(changes.deleted[0].name, "screenly_bearer_token");
     }
 
     #[test]
@@ -818,11 +818,11 @@ mod tests {
         assert!(changes
             .creates
             .iter()
-            .any(|s| s.name == "basic_auth_username" && s.is_global));
+            .any(|s| s.name == "screenly_basic_auth_username" && s.is_global));
         assert!(changes
             .creates
             .iter()
-            .any(|s| s.name == "basic_auth_password" && s.is_global));
+            .any(|s| s.name == "screenly_basic_auth_password" && s.is_global));
     }
 
     #[test]

--- a/src/commands/manifest_auth.rs
+++ b/src/commands/manifest_auth.rs
@@ -16,14 +16,14 @@ impl AuthType {
                 Setting::new(
                     SettingType::String,
                     "Username",
-                    "basic_auth_username",
+                    "screenly_basic_auth_username",
                     "The username for Basic Authentication.",
                     global,
                 ),
                 Setting::new(
                     SettingType::Secret,
                     "Password",
-                    "basic_auth_password",
+                    "screenly_basic_auth_password",
                     "The password for Basic Authentication.",
                     global,
                 ),
@@ -31,7 +31,7 @@ impl AuthType {
             AuthType::Bearer => vec![Setting::new(
                 SettingType::String,
                 "Token",
-                "bearer_token",
+                "screenly_bearer_token",
                 "The Bearer token for authentication.",
                 global,
             )],
@@ -52,7 +52,7 @@ mod tests {
 
         let username_setting = &settings[0];
         assert_eq!(username_setting.type_, SettingType::String);
-        assert_eq!(username_setting.name, "basic_auth_username");
+        assert_eq!(username_setting.name, "screenly_basic_auth_username");
         assert_eq!(username_setting.title, Some("Username".to_string()));
         assert!(!username_setting.optional);
         assert!(username_setting
@@ -61,7 +61,7 @@ mod tests {
 
         let password_setting = &settings[1];
         assert_eq!(password_setting.type_, SettingType::Secret);
-        assert_eq!(password_setting.name, "basic_auth_password");
+        assert_eq!(password_setting.name, "screenly_basic_auth_password");
         assert_eq!(password_setting.title, Some("Password".to_string()));
         assert!(!password_setting.optional);
         assert!(password_setting
@@ -78,7 +78,7 @@ mod tests {
 
         let token_setting = &settings[0];
         assert_eq!(token_setting.type_, SettingType::String);
-        assert_eq!(token_setting.name, "bearer_token");
+        assert_eq!(token_setting.name, "screenly_bearer_token");
         assert_eq!(token_setting.title, Some("Token".to_string()));
         assert!(!token_setting.optional);
         assert!(token_setting


### PR DESCRIPTION
Renames auth settings to have screenly_ prepended.