### PR TITLE
Adds: restrict 'screenly_*' names for settings on validation.

### DIFF
--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -742,6 +742,30 @@ settings:
     }
 
     #[test]
+    fn test_ensure_manifest_is_valid_when_setting_starts_with_predefined_string_should_fail() {
+        let dir = tempdir().unwrap();
+        let file_name = "screenly.yml";
+        let content = r#"---
+syntax: manifest_v1
+id: test_app
+settings:
+  screenly_setting:
+    type: string
+    default_value: stranger
+    title: some_setting
+    optional: true
+    help_text: An example of a setting that is used in index.html
+"#;
+
+        let file_path = write_to_tempfile(&dir, file_name, content);
+        let result = EdgeAppManifest::ensure_manifest_is_valid(&file_path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains( 
+            "Setting \"screenly_setting\" cannot start with \"screenly_\""
+        ));
+    }
+
+    #[test]
     fn test_save_manifest_to_file_with_is_global_true_should_save_yaml_correctly() {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("screenly.yml");

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -761,7 +761,7 @@ settings:
         let result = EdgeAppManifest::ensure_manifest_is_valid(&file_path);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains( 
-            "Setting \"screenly_setting\" cannot start with \"screenly_\""
+            "Setting \"screenly_setting\" cannot start with \"screenly_\" as this prefix is preserved."
         ));
     }
 

--- a/src/commands/edge_app_settings.rs
+++ b/src/commands/edge_app_settings.rs
@@ -90,7 +90,7 @@ where
         }
         if setting.name.starts_with("screenly_") {
             return Err(serde::de::Error::custom(format!(
-                "Setting \"{}\" cannot start with \"screenly_\"",
+                "Setting \"{}\" cannot start with \"screenly_\" as this prefix is preserved.",
                 setting.name
             )));
         }

--- a/src/commands/edge_app_settings.rs
+++ b/src/commands/edge_app_settings.rs
@@ -88,6 +88,12 @@ where
                 setting.name
             )));
         }
+        if setting.name.starts_with("screenly_") {
+            return Err(serde::de::Error::custom(format!(
+                "Setting \"{}\" cannot start with \"screenly_\"",
+                setting.name
+            )));
+        }
     }
 
     settings.sort_by_key(|s| s.name.clone());


### PR DESCRIPTION
When calling validate command, fails if there is a setting starting with 'screenly_' as it is now reserved names for settings.