### PR TITLE
Adds: intervalidation of manifests for entrypoint

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1001,7 +1001,7 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             let instance_manifest_path = match transform_instance_path_to_instance_manifest(path) {
                 Ok(path) => path,
                 Err(e) => {
-                    eprintln!("Failed to validate edge app instance file path: {e}.");
+                    eprintln!("Failed to build instance manifest filepath: {e}.");
                     std::process::exit(1);
                 }
             };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1006,6 +1006,11 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 }
             };
 
+            if !instance_manifest_path.exists() {
+                println!("Instance manifest file does not exist.");
+                std::process::exit(0);
+            }
+
             match InstanceManifest::ensure_manifest_is_valid(&instance_manifest_path) {
                 Ok(()) => {
                     println!("Instance manifest file is valid.");

--- a/src/commands/edge_app.rs
+++ b/src/commands/edge_app.rs
@@ -1393,7 +1393,16 @@ mod tests {
         }
     }
 
-    fn prepare_edge_apps_test(create_manifest: bool, create_instance_manifest: bool) -> (TempDir, EdgeAppCommand, MockServer, Option<EdgeAppManifest>, Option<InstanceManifest>) {
+    fn prepare_edge_apps_test(
+        create_manifest: bool,
+        create_instance_manifest: bool,
+    ) -> (
+        TempDir,
+        EdgeAppCommand,
+        MockServer,
+        Option<EdgeAppManifest>,
+        Option<InstanceManifest>,
+    ) {
         let tmp_dir = tempdir().unwrap();
         let mock_server = MockServer::start();
         let config = Config::new(mock_server.base_url());
@@ -1402,7 +1411,11 @@ mod tests {
 
         let edge_app_manifest = if create_manifest {
             let edge_app_manifest = create_edge_app_manifest_for_test(vec![]);
-            EdgeAppManifest::save_to_file(&edge_app_manifest, tmp_dir.path().join("screenly.yml").as_path()).unwrap();
+            EdgeAppManifest::save_to_file(
+                &edge_app_manifest,
+                tmp_dir.path().join("screenly.yml").as_path(),
+            )
+            .unwrap();
             Some(edge_app_manifest)
         } else {
             None
@@ -1410,17 +1423,28 @@ mod tests {
 
         let instance_manifest = if create_instance_manifest {
             let instance_manifest = create_instance_manifest_for_test();
-            InstanceManifest::save_to_file(&instance_manifest, tmp_dir.path().join("instance.yml").as_path()).unwrap();
+            InstanceManifest::save_to_file(
+                &instance_manifest,
+                tmp_dir.path().join("instance.yml").as_path(),
+            )
+            .unwrap();
             Some(instance_manifest)
         } else {
             None
         };
 
-        (tmp_dir, command, mock_server, edge_app_manifest, instance_manifest)
+        (
+            tmp_dir,
+            command,
+            mock_server,
+            edge_app_manifest,
+            instance_manifest,
+        )
     }
     #[test]
     fn test_edge_app_create_should_create_app_and_required_files() {
-        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let post_mock = mock_server.mock(|when, then| {
             when.method(POST)
@@ -1487,7 +1511,8 @@ mod tests {
 
     #[test]
     fn test_edge_app_create_when_manifest_or_index_html_exist_should_return_error() {
-        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, false);
+        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, false);
 
         let result = command.create(
             "Best app ever",
@@ -1518,7 +1543,8 @@ mod tests {
 
     #[test]
     fn test_create_in_place_edge_app_should_create_edge_app_using_existing_files() {
-        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let post_mock = mock_server.mock(|when, then| {
             when.method(POST)
@@ -1558,7 +1584,8 @@ mod tests {
 
     #[test]
     fn test_create_in_place_edge_app_when_manifest_or_index_html_missed_should_return_error() {
-        let (tmp_dir, command, _mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (tmp_dir, command, _mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         File::create(tmp_dir.path().join("screenly.yml")).unwrap();
 
@@ -1591,7 +1618,8 @@ mod tests {
 
     #[test]
     fn test_create_in_place_edge_app_when_manifest_has_non_empty_app_id_should_return_error() {
-        let (tmp_dir, command, _mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (tmp_dir, command, _mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         File::create(tmp_dir.path().join("index.html")).unwrap();
 
@@ -1618,7 +1646,8 @@ mod tests {
 
     #[test]
     fn test_list_edge_apps_should_send_correct_request() {
-        let (_tmp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (_tmp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let edge_apps_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -1638,7 +1667,8 @@ mod tests {
 
     #[test]
     fn test_list_settings_should_send_correct_request() {
-        let (_tmp_dir, command, mock_server, _manifest, instance_manifest) = prepare_edge_apps_test(false, true);
+        let (_tmp_dir, command, mock_server, _manifest, instance_manifest) =
+            prepare_edge_apps_test(false, true);
 
         let installations_get_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -1779,7 +1809,8 @@ mod tests {
 
     #[test]
     fn test_set_setting_should_send_correct_request() {
-        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let setting_get_is_global_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -1851,7 +1882,8 @@ mod tests {
 
     #[test]
     fn test_set_setting_when_setting_value_exists_should_send_correct_update_request() {
-        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (tmp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let setting_get_is_global_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -1934,7 +1966,8 @@ mod tests {
 
     #[test]
     fn test_set_global_setting_when_setting_value_exists_should_send_correct_update_request() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let setting_is_global_get_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -2016,7 +2049,8 @@ mod tests {
 
     #[test]
     fn test_set_global_setting_when_setting_value_not_exists_should_send_correct_create_request() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let setting_is_global_get_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -2087,7 +2121,8 @@ mod tests {
 
     #[test]
     fn test_set_setting_when_setting_doesnt_exist_should_fail() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let setting_get_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -2121,7 +2156,8 @@ mod tests {
 
     #[test]
     fn test_set_setting_with_secret_should_send_correct_request() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let setting_is_global_get_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -2200,7 +2236,8 @@ mod tests {
 
     #[test]
     fn test_set_global_secrets_should_send_correct_request() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let setting_is_global_get_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -2280,7 +2317,8 @@ mod tests {
 
     #[test]
     fn test_set_setting_when_value_has_not_changed_should_not_update_it() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let setting_get_is_global_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -2344,7 +2382,8 @@ mod tests {
 
     #[test]
     fn test_deploy_should_send_correct_requests() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let mut manifest = create_edge_app_manifest_for_test(vec![
             Setting {
@@ -2685,7 +2724,8 @@ mod tests {
 
     #[test]
     fn test_detect_version_metadata_changes_when_no_changes_should_return_false() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let manifest = create_edge_app_manifest_for_test(vec![
             Setting {
@@ -2718,7 +2758,7 @@ mod tests {
                 )
                 .query_param(
                     "select",
-                    "user_version,description,icon,author,homepage_url,revision,ready_signal"
+                    "user_version,description,icon,author,homepage_url,revision,ready_signal",
                 )
                 .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
                 .query_param("order", "revision.desc")
@@ -2751,7 +2791,8 @@ mod tests {
 
     #[test]
     fn test_detect_version_metadata_changes_when_has_changes_should_return_true() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let manifest = create_edge_app_manifest_for_test(vec![
             Setting {
@@ -2817,7 +2858,8 @@ mod tests {
 
     #[test]
     fn test_detect_version_metadata_changes_when_no_version_exist_should_return_false() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let manifest = create_edge_app_manifest_for_test(vec![
             Setting {
@@ -2873,7 +2915,8 @@ mod tests {
 
     #[test]
     fn test_generate_mock_data_creates_file_with_expected_content() {
-        let (dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("test_manifest.yml");
 
@@ -2962,7 +3005,8 @@ mod tests {
 
     #[test]
     fn test_ensure_assets_processing_finished_when_processing_failed_should_return_error() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let manifest = create_edge_app_manifest_for_test(vec![
             Setting {
@@ -3021,7 +3065,8 @@ mod tests {
 
     #[test]
     fn test_update_name_should_send_correct_request() {
-        let (_temp_dir, command, mock_server, manifest, _instance_manifest) = prepare_edge_apps_test(true, false);
+        let (_temp_dir, command, mock_server, manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, false);
 
         let update_name_mock = mock_server.mock(|when, then| {
             when.method(PATCH)
@@ -3052,7 +3097,8 @@ mod tests {
 
     #[test]
     fn test_delete_app_should_send_correct_request() {
-        let (_temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (_temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         mock_server.mock(|when, then| {
             when.method(DELETE)
@@ -3071,7 +3117,8 @@ mod tests {
 
     #[test]
     fn test_clear_app_id_should_remove_app_id_from_manifest() {
-        let (temp_dir, command, _mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, false);
+        let (temp_dir, command, _mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, false);
 
         let manifest_path = temp_dir.path().join("screenly.yml");
         assert!(command.clear_app_id(&manifest_path).is_ok());
@@ -3101,7 +3148,8 @@ mod tests {
 
     #[test]
     fn test_upload_without_app_id_should_fail() {
-        let (temp_dir, command, _mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (temp_dir, command, _mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let mut manifest = create_edge_app_manifest_for_test(vec![
             Setting {
@@ -3146,7 +3194,8 @@ mod tests {
 
     #[test]
     fn test_changed_files_when_not_all_files_are_copied_should_upload_missed_ones() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let manifest = EdgeAppManifest {
             syntax: MANIFEST_VERSION.to_owned(),
@@ -3260,7 +3309,8 @@ mod tests {
 
     #[test]
     fn test_changed_files_when_all_files_are_copied_should_not_upload() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let manifest = EdgeAppManifest {
             syntax: MANIFEST_VERSION.to_owned(),
@@ -3365,7 +3415,8 @@ mod tests {
 
     #[test]
     fn test_create_is_global_setting_should_pass_is_global_property() {
-        let (_temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, false);
+        let (_temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, false);
 
         //  v4/edge-apps/settings?app_id=eq.{}
         let settings_mock_create = mock_server.mock(|when, then| {
@@ -3418,8 +3469,9 @@ mod tests {
     #[test]
     fn test_maybe_delete_missing_settings_when_ci_is_1_and_no_arg_provided_should_ignore_deleting_settings(
     ) {
-        let (_temp_dir, command, _mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, false);
-        
+        let (_temp_dir, command, _mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, false);
+
         let changed_settings: SettingChanges = SettingChanges {
             creates: vec![],
             updates: vec![],
@@ -3442,12 +3494,12 @@ mod tests {
             );
             assert!(result.is_ok());
         });
-        
     }
 
     #[test]
     fn test_instance_list_should_list_instances() {
-        let (_temp_dir, command, mock_server, manifest, _instance_manifest) = prepare_edge_apps_test(true, false);
+        let (_temp_dir, command, mock_server, manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, false);
 
         let installations_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -3497,7 +3549,8 @@ mod tests {
 
     #[test]
     fn test_create_instance_should_create_instance() {
-        let (temp_dir, command, mock_server, manifest, _instance_manifest) = prepare_edge_apps_test(true, false);
+        let (temp_dir, command, mock_server, manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, false);
 
         let instance_manifest_path = temp_dir.path().join("instance.yml");
 
@@ -3538,7 +3591,8 @@ mod tests {
 
     #[test]
     fn test_create_instance_when_instance_exist_should_fail() {
-        let (temp_dir, command, _mock_server, manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, _mock_server, manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let instance_manifest_path = temp_dir.path().join("instance.yml");
         let result = command.create_instance(
@@ -3554,7 +3608,8 @@ mod tests {
 
     #[test]
     fn test_update_instance_when_name_changed_should_update_instance() {
-        let (temp_dir, command, mock_server, manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let get_instance_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -3595,7 +3650,8 @@ mod tests {
 
     #[test]
     fn test_update_instance_when_name_not_changed_should_not_update_instance() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let get_instance_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -3618,8 +3674,9 @@ mod tests {
 
     #[test]
     fn test_update_instance_when_entrypoint_uri_added_should_create_entrypoint_setting_value() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
-        
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
+
         let mut manifest = _manifest.unwrap();
         let mut instance_manifest = _instance_manifest.unwrap();
 
@@ -3630,8 +3687,11 @@ mod tests {
         instance_manifest.entrypoint_uri = Some("https://local-entrypoint.com".to_string());
         EdgeAppManifest::save_to_file(&manifest, temp_dir.path().join("screenly.yml").as_path())
             .unwrap();
-        InstanceManifest::save_to_file(&instance_manifest, temp_dir.path().join("instance.yml").as_path())
-            .unwrap();
+        InstanceManifest::save_to_file(
+            &instance_manifest,
+            temp_dir.path().join("instance.yml").as_path(),
+        )
+        .unwrap();
 
         let get_instance_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -3643,8 +3703,7 @@ mod tests {
                     "user-agent",
                     format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
                 );
-            then.status(200)
-                .json_body(json!([{"name": "test"}]));
+            then.status(200).json_body(json!([{"name": "test"}]));
         });
 
         let setting_get_is_global_mock = mock_server.mock(|when, then| {
@@ -3714,8 +3773,9 @@ mod tests {
 
     #[test]
     fn test_update_instance_when_entrypoint_uri_updated_should_update_entrypoint_setting_value() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
-        
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
+
         let mut manifest = _manifest.unwrap();
         let mut instance_manifest = _instance_manifest.unwrap();
 
@@ -3726,8 +3786,11 @@ mod tests {
         instance_manifest.entrypoint_uri = Some("https://local-entrypoint2.com".to_string());
         EdgeAppManifest::save_to_file(&manifest, temp_dir.path().join("screenly.yml").as_path())
             .unwrap();
-        InstanceManifest::save_to_file(&instance_manifest, temp_dir.path().join("instance.yml").as_path())
-            .unwrap();
+        InstanceManifest::save_to_file(
+            &instance_manifest,
+            temp_dir.path().join("instance.yml").as_path(),
+        )
+        .unwrap();
 
         let get_instance_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -3739,8 +3802,7 @@ mod tests {
                     "user-agent",
                     format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
                 );
-            then.status(200)
-                .json_body(json!([{"name": "test"}]));
+            then.status(200).json_body(json!([{"name": "test"}]));
         });
 
         let setting_get_is_global_mock = mock_server.mock(|when, then| {
@@ -3821,7 +3883,8 @@ mod tests {
 
     #[test]
     fn test_delete_instance_should_delete_instance() {
-        let (temp_dir, command, mock_server, manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, mock_server, manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let instance_manifest_path = temp_dir.path().join("instance.yml");
 
@@ -3850,7 +3913,8 @@ mod tests {
 
     #[test]
     fn test_get_installation_id_when_manifest_has_id_should_return_id() {
-        let (temp_dir, command, _mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(true, true);
+        let (temp_dir, command, _mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(true, true);
 
         let result =
             command.get_installation_id(Some(temp_dir.path().to_str().unwrap().to_string()));
@@ -3863,7 +3927,8 @@ mod tests {
     #[test]
     fn test_update_entrypoint_value_when_entrypoint_is_global_and_it_is_not_set_should_post_value()
     {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, true);
 
         let setting_is_global_get_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -3943,7 +4008,8 @@ mod tests {
 
     #[test]
     fn test_update_entrypoint_value_when_entrypoint_is_global_and_setting_is_set_should_patch_it() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, true);
+        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, true);
 
         let setting_is_global_get_mock = mock_server.mock(|when, then| {
             when.method(GET)
@@ -4033,7 +4099,8 @@ mod tests {
 
     #[test]
     fn test_update_entrypoint_value_when_entrypoint_is_local_and_it_is_not_set_should_post_value() {
-        let (_temp_dir, command, mock_server, _manifest, _instance_manifest) = prepare_edge_apps_test(false, false);
+        let (_temp_dir, command, mock_server, _manifest, _instance_manifest) =
+            prepare_edge_apps_test(false, false);
 
         let setting_is_global_get_mock = mock_server.mock(|when, then| {
             when.method(GET)

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -760,7 +760,7 @@ settings:
         let file_path = write_to_tempfile(&dir, file_name, content);
         let result = EdgeAppManifest::ensure_manifest_is_valid(&file_path);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains( 
+        assert!(result.unwrap_err().to_string().contains(
             "Setting \"screenly_setting\" cannot start with \"screenly_\" as this prefix is preserved."
         ));
     }

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -117,10 +117,6 @@ pub struct EdgeAppManifest {
     pub settings: Vec<Setting>,
 }
 
-fn default_syntax() -> String {
-    MANIFEST_VERSION.to_owned()
-}
-
 fn deserialize_auth<'de, D>(deserializer: D) -> Result<Option<Auth>, D::Error>
 where
     D: serde::de::Deserializer<'de>,

--- a/src/commands/edge_app_manifest.rs
+++ b/src/commands/edge_app_manifest.rs
@@ -760,9 +760,10 @@ settings:
         let file_path = write_to_tempfile(&dir, file_name, content);
         let result = EdgeAppManifest::ensure_manifest_is_valid(&file_path);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains( 
-            "Setting \"screenly_setting\" cannot start with \"screenly_\""
-        ));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Setting \"screenly_setting\" cannot start with \"screenly_\""));
     }
 
     #[test]

--- a/src/commands/edge_app_settings.rs
+++ b/src/commands/edge_app_settings.rs
@@ -10,14 +10,6 @@ use strum_macros::{Display, EnumIter, EnumString};
 
 use crate::commands::serde_utils::{deserialize_string_field, serialize_non_empty_string_field};
 
-const RESERVED_SETTING_NAMES: &[&str] = &[
-    "basic_auth_username",
-    "basic_auth_password",
-    "bearer_token",
-    "azure_ad_client_id",
-    "azure_ad_client_secret",
-];
-
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Default, EnumString, Display, EnumIter)]
 pub enum SettingType {
     #[default]

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -1,7 +1,7 @@
 use crate::commands::edge_app::AssetSignature;
 use crate::commands::edge_app_manifest::EdgeAppManifest;
 use crate::commands::edge_app_settings::{Setting, SettingType};
-use crate::commands::instance_manifest::{InstanceManifest, INSTANCE_MANIFEST_VERSION};
+use crate::commands::instance_manifest::InstanceManifest;
 use crate::commands::CommandError;
 use crate::signature::{generate_signature, sig_to_hex};
 use log::debug;
@@ -281,12 +281,10 @@ pub fn validate_manifests_dependacies(
                 }
             }
         }
-    } else {
-        if instance_manifest.entrypoint_uri.is_some() {
-            return Err(CommandError::InvalidManifest(
-                "entrypoint_uri must not be set when entrypoint is not set".to_owned(),
-            ));
-        }
+    } else if instance_manifest.entrypoint_uri.is_some() {
+        return Err(CommandError::InvalidManifest(
+            "entrypoint_uri must not be set when entrypoint is not set".to_owned(),
+        ));
     }
     Ok(())
 }
@@ -295,6 +293,7 @@ pub fn validate_manifests_dependacies(
 mod tests {
     use super::*;
     use crate::commands::edge_app_manifest::{Auth, Entrypoint, EntrypointType, MANIFEST_VERSION};
+    use crate::commands::instance_manifest::INSTANCE_MANIFEST_VERSION;
     use crate::commands::manifest_auth::AuthType;
     use crate::commands::SettingType;
     use std::fs::File;

--- a/src/commands/edge_app_utils.rs
+++ b/src/commands/edge_app_utils.rs
@@ -1,6 +1,7 @@
 use crate::commands::edge_app::AssetSignature;
 use crate::commands::edge_app_manifest::EdgeAppManifest;
 use crate::commands::edge_app_settings::{Setting, SettingType};
+use crate::commands::instance_manifest::{InstanceManifest, INSTANCE_MANIFEST_VERSION};
 use crate::commands::CommandError;
 use crate::signature::{generate_signature, sig_to_hex};
 use log::debug;
@@ -256,6 +257,38 @@ pub fn generate_file_tree(files: &[EdgeAppFile], root_path: &Path) -> HashMap<St
     debug!("File tree: {:?}", &tree);
 
     tree
+}
+
+pub fn validate_manifests_dependacies(
+    manifest: &EdgeAppManifest,
+    instance_manifest: &InstanceManifest,
+) -> Result<(), CommandError> {
+    if let Some(entrypoint) = &manifest.entrypoint {
+        match entrypoint.entrypoint_type {
+            crate::commands::edge_app_manifest::EntrypointType::RemoteLocal => {
+                if instance_manifest.entrypoint_uri.is_none() {
+                    return Err(CommandError::InvalidManifest(
+                        "entrypoint_uri must be set for remote local entrypoint".to_owned(),
+                    ));
+                }
+            }
+            _ => {
+                if instance_manifest.entrypoint_uri.is_some() {
+                    return Err(CommandError::InvalidManifest(
+                        "entrypoint_uri must not be set when entrypoint is not remote local"
+                            .to_owned(),
+                    ));
+                }
+            }
+        }
+    } else {
+        if instance_manifest.entrypoint_uri.is_some() {
+            return Err(CommandError::InvalidManifest(
+                "entrypoint_uri must not be set when entrypoint is not set".to_owned(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -849,7 +882,8 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_changed_settings_when_entrypoint_setting_exist_in_remote_should_not_create_global_setting() {
+    fn test_detect_changed_settings_when_entrypoint_setting_exist_in_remote_should_not_create_global_setting(
+    ) {
         let mut manifest = create_manifest();
         manifest.entrypoint = Some(Entrypoint {
             entrypoint_type: EntrypointType::RemoteGlobal,
@@ -991,5 +1025,109 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(result.unwrap_err().to_string(), "Env var INSTANCE_FILENAME must hold only file name, not a path. folder/instance2.yml");
         });
+    }
+
+    #[test]
+    fn test_validate_manifests_dependacies_when_entrypoint_type_is_not_remote_local_and_entrypoint_uri_is_set_should_fail(
+    ) {
+        let mut manifest = EdgeAppManifest {
+            id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            auth: None,
+            syntax: MANIFEST_VERSION.to_owned(),
+            ready_signal: None,
+            user_version: Some("1".to_string()),
+            description: Some("asdf".to_string()),
+            icon: Some("asdf".to_string()),
+            author: Some("asdf".to_string()),
+            homepage_url: Some("asdfasdf".to_string()),
+            entrypoint: Some(Entrypoint {
+                entrypoint_type: EntrypointType::File,
+                uri: None,
+            }),
+            settings: vec![],
+        };
+
+        let instance_manifest = InstanceManifest {
+            entrypoint_uri: Some("entrypoint.html".to_string()),
+            syntax: INSTANCE_MANIFEST_VERSION.to_owned(),
+            id: Some("01B2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            name: "instance".to_string(),
+        };
+
+        let result = validate_manifests_dependacies(&manifest, &instance_manifest);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "Manifest file validation failed with error: entrypoint_uri must not be set when entrypoint is not remote local");
+
+        manifest.entrypoint = Some(Entrypoint {
+            entrypoint_type: EntrypointType::RemoteGlobal,
+            uri: None,
+        });
+
+        let result = validate_manifests_dependacies(&manifest, &instance_manifest);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "Manifest file validation failed with error: entrypoint_uri must not be set when entrypoint is not remote local");
+    }
+
+    #[test]
+    fn test_validate_manifests_dependacies_when_entrypoint_type_is_remote_local_and_entrypoint_uri_is_not_set_should_fail(
+    ) {
+        let manifest = EdgeAppManifest {
+            id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            auth: None,
+            syntax: MANIFEST_VERSION.to_owned(),
+            ready_signal: None,
+            user_version: Some("1".to_string()),
+            description: Some("asdf".to_string()),
+            icon: Some("asdf".to_string()),
+            author: Some("asdf".to_string()),
+            homepage_url: Some("asdfasdf".to_string()),
+            entrypoint: Some(Entrypoint {
+                entrypoint_type: EntrypointType::RemoteLocal,
+                uri: None,
+            }),
+            settings: vec![],
+        };
+
+        let instance_manifest = InstanceManifest {
+            entrypoint_uri: None,
+            syntax: INSTANCE_MANIFEST_VERSION.to_owned(),
+            id: Some("01B2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            name: "instance".to_string(),
+        };
+
+        let result = validate_manifests_dependacies(&manifest, &instance_manifest);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "Manifest file validation failed with error: entrypoint_uri must be set for remote local entrypoint");
+    }
+
+    #[test]
+    fn test_validate_manifests_dependacies_when_entrypoint_type_is_remote_local_and_entrypoint_uri_is_set_should_succeed(
+    ) {
+        let manifest = EdgeAppManifest {
+            id: Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            auth: None,
+            syntax: MANIFEST_VERSION.to_owned(),
+            ready_signal: None,
+            user_version: Some("1".to_string()),
+            description: Some("asdf".to_string()),
+            icon: Some("asdf".to_string()),
+            author: Some("asdf".to_string()),
+            homepage_url: Some("asdfasdf".to_string()),
+            entrypoint: Some(Entrypoint {
+                entrypoint_type: EntrypointType::RemoteLocal,
+                uri: None,
+            }),
+            settings: vec![],
+        };
+
+        let instance_manifest = InstanceManifest {
+            entrypoint_uri: Some("https://remote-local.com".to_string()),
+            syntax: INSTANCE_MANIFEST_VERSION.to_owned(),
+            id: Some("01B2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            name: "instance".to_string(),
+        };
+
+        let result = validate_manifests_dependacies(&manifest, &instance_manifest);
+        assert!(result.is_ok());
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -112,10 +112,8 @@ pub enum CommandError {
     InitializationError(String),
     #[error("Asset processing error: {0}")]
     AssetProcessingError(String),
-    #[error("App id is required. Either in manifest or with --app-id.")]
+    #[error("App id is required in manifest.")]
     MissingAppId,
-    #[error("App id cannot be empty. Provide it either in manifest.")]
-    EmptyAppId,
     #[error("Edge App Revision {0} not found")]
     RevisionNotFound(String),
     #[error("Manifest file validation failed with error: {0}")]


### PR DESCRIPTION
Adds: validate instance manifest if it exists.
Validate entrypoint configuration between manifests.