### PR TITLE
chore(deps): bump time to 0.3.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,13 +2684,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -2700,10 +2707,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 


### PR DESCRIPTION
## What does this PR do?

Bumps the `time` rust dependency to 0.3.36. Without it, the `cli` package won't build with `rust > 1.80.0`, which was pointed out in https://github.com/NixOS/nixpkgs/issues/332957

## GitHub issue or Phabricator ticket number?

https://github.com/NixOS/nixpkgs/issues/332957

## How has this been tested?

Fairly naively - I bumped the dependency and checked the code still builds. I also ran `cargo test`, which completed successfully:

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 30.90s
     Running unittests src/main.rs (target/debug/deps/screenly-d041db5838078ffc)

running 115 tests
test authentication::tests::test_read_token_correct_token_is_returned ... ok
test authentication::tests::test_read_token_when_token_is_overridden_with_env_variable_correct_token_is_returned ... ok
test cli::tests::test_transform_edge_app_path_to_manifest_without_path_should_return_correct_path ... ok
test cli::tests::test_transform_edge_app_path_to_manifest_with_path_should_return_correct_path ... ok
test commands::asset::tests::test_format_asset_when_human_readable_output_is_set_should_return_correct_formatted_string ... ok
test commands::edge_app::tests::test_create_in_place_edge_app_when_manifest_or_index_html_missed_should_return_error ... ok
test commands::edge_app::tests::test_create_in_place_edge_app_when_manifest_has_non_empty_app_id_should_return_error ... ok
test commands::edge_app::tests::test_edge_app_create_when_manifest_or_index_html_exist_should_return_error ... ok
test commands::edge_app::tests::test_ensure_installation_id_when_installation_id_is_in_args_should_return_args_installation_id ... ok
test commands::edge_app::tests::test_ensure_installation_id_when_installation_id_not_in_parameters_and_not_in_manifest_and_app_id_is_not_in_manifest_should_fail ... ok
test commands::edge_app::tests::test_generate_mock_data_creates_file_with_expected_content ... ok
test commands::edge_app::tests::test_ensure_installation_id_when_installation_id_is_not_in_args_and_in_manifest_should_return_manifest_installation_id ... ok
test commands::edge_app::tests::test_generate_mock_data_excludes_secret_settings ... ok
test commands::edge_app::tests::test_clear_app_id_should_remove_app_id_from_manifest ... ok
test commands::asset::tests::test_delete_asset_should_send_correct_request ... ok
test commands::asset::tests::test_inject_js_should_send_correct_request ... ok
test commands::asset::tests::test_add_asset_when_local_asset_should_send_correct_request ... ok
test commands::asset::tests::test_get_asset_should_return_asset ... ok
test commands::asset::tests::test_add_asset_when_web_asset_should_send_correct_request ... ok
test commands::asset::tests::test_list_assets_should_return_correct_asset_list ... ok
test cli::tests::test_get_screen_name_should_return_correct_screen_name ... ok
test authentication::tests::test_verify_and_store_token_when_token_is_valid ... ok
test commands::asset::tests::test_set_headers_should_send_correct_request ... ok
test commands::edge_app::tests::test_create_is_global_setting_should_pass_is_global_property ... ok
test commands::edge_app::tests::test_detect_version_metadata_changes_when_has_changes_should_return_true ... ok
test commands::edge_app::tests::test_list_edge_apps_should_send_correct_request ... ok
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/2test commands::edge_app::tests::test_ensure_installation_id_when_app_id_in_manifest_and_installation_id_missing_and_old_name_installation_exist_should_save_installation_id_to_manifest ... ok
test commands::edge_app::tests::test_ensure_assets_processing_finished_when_processing_failed_should_return_error ... ok
test commands::edge_app::tests::test_detect_version_metadata_changes_when_no_version_exist_should_return_false ... ok
test commands::edge_app::tests::test_delete_app_should_send_correct_request ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_empty_required_field_should_return_error ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_file_non_existent_should_return_error ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_file_valid_should_return_ok ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_invaild_type_should_return_error ... ok
test commands::edge_app::tests::test_upload_without_app_id_should_fail ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_invalid_field_should_return_error ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_missing_field_should_return_error ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_required_empty_field_should_return_error ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_required_string_field_has_no_default_value_should_succeed ... ok
test commands::edge_app_manifest::tests::test_ensure_manifest_is_valid_when_secret_field_has_default_value_should_fail ... ok
test commands::edge_app_manifest::tests::test_prepare_manifest_payload_includes_some_fields ... ok
test commands::edge_app_manifest::tests::test_prepare_manifest_payload_omits_none_fields ... ok
test commands::edge_app_manifest::tests::test_save_manifest_to_file_should_fail_on_empty_help_text_in_setting ... ok
test commands::edge_app_manifest::tests::test_save_manifest_to_file_should_save_yaml_correctly ... ok
test commands::edge_app_manifest::tests::test_save_manifest_to_file_should_skip_default_optional_fields ... ok
test commands::edge_app_manifest::tests::test_save_manifest_to_file_should_skip_empty_optional_fields ... ok
test commands::edge_app_manifest::tests::test_save_manifest_to_file_should_skip_none_optional_fields ... ok
test commands::edge_app_manifest::tests::test_save_manifest_to_file_with_is_global_true_should_save_yaml_correctly ... ok
test commands::edge_app_manifest::tests::test_serialize_deserialize_cycle_should_pass_on_valid_struct ... ok
test commands::edge_app_manifest::tests::test_serialize_deserialize_cycle_should_pass_on_valid_struct_missing_optional_fields ... ok
test commands::edge_app_manifest::tests::test_serialize_deserialize_cycle_with_is_global_setting_should_pass ... ok
test commands::edge_app::tests::test_changed_files_when_all_files_are_copied_should_not_upload ... ok
test commands::edge_app::tests::test_create_version_when_entrypoint_present_should_include_in_payload ... ok
test commands::edge_app_utils::tests::test_detect_changed_files_changes_detected ... ok
test commands::edge_app_utils::tests::test_detect_changed_files_no_changes ... ok
test commands::edge_app_utils::tests::test_detect_changed_files_remote_files_empty ... ok
test commands::edge_app_utils::tests::test_detect_changed_settings_when_is_global_changed_on_setting_should_detect_changes ... ok
test commands::edge_app_utils::tests::test_detect_changed_settings_when_no_changes_should_detect_no_changes ... ok
test commands::edge_app_utils::tests::test_detect_changed_settings_when_no_remote_settings_should_detect_changes ... ok
test commands::edge_app::tests::test_maybe_delete_missing_settings_when_ci_is_1_and_no_arg_provided_should_ignore_deleting_settings ... ok
test commands::edge_app_utils::tests::test_detect_changed_settings_when_setting_are_modified_should_detect_changes ... ok
test commands::edge_app::tests::test_detect_version_metadata_changes_when_no_changes_should_return_false ... ok
test commands::edge_app_utils::tests::test_detect_changed_when_files_local_deleted_should_detect_changes ... ok
test commands::edge_app_utils::tests::test_detect_changes_settings_when_local_setting_added_should_detect_changes ... ok
test commands::edge_app_utils::tests::test_detect_changes_settings_when_setting_removed_should_detect_deleted_changes ... ok
test commands::edge_app_utils::tests::test_ignore_functionality ... ok
test commands::ignorer::tests::test_ignore_when_pattern_specified_should_ignore_files_matching_that_pattern ... ok
test commands::ignorer::tests::test_ignore_when_directory_specified_should_ignore_that_directory ... ok
test commands::ignorer::tests::test_when_no_ignore_file_should_ignore_nothing ... ok
test commands::ignorer::tests::test_ignore_when_specific_file_in_ignore_list_should_ignore_it ... ok
test commands::ignorer::tests::test_ignore_when_top_level_directory_ignored_should_also_ignore_nested_subdirs ... ok
test commands::edge_app::tests::test_promote_when_there_are_undefined_settings_should_fail ... ok
test commands::asset::tests::test_update_headers_should_send_correct_request ... ok
test authentication::tests::test_verify_and_store_token_when_base_url_is_overdriven ... ok
test commands::edge_app::tests::test_list_secrets_should_send_correct_request ... ok
█████████████████████████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1/2test commands::edge_app::tests::test_update_entrypoint_if_needed_when_remote_entrypoint_is_same_as_from_manifest_should_not_patch_remote ... ok
test commands::edge_app::tests::test_changed_files_when_not_all_files_are_copied_should_upload_missed_ones ... ok
test commands::edge_app::tests::test_update_name_should_send_correct_request ... ok
test commands::screen::tests::test_format_screen_when_human_readable_output_is_set_should_return_correct_formatted_string ... ok
test commands::edge_app::tests::test_list_versions_should_send_correct_request ... ok
test commands::edge_app::tests::test_edge_app_create_should_create_app_and_required_files ... ok
test commands::tests::test_edge_app_versions_formatter_format_output_properly ... ok
test signature::tests::test_generate_signature_should_generate_correct_signature_for_file ... ok
test signature::tests::test_generate_signature_when_file_does_not_exist_should_return_error ... ok
test commands::edge_app_server::tests::test_server_when_invalid_version_requested_should_return ... ok
test commands::edge_app::tests::test_create_in_place_edge_app_should_create_edge_app_using_existing_files ... ok
test commands::edge_app_server::tests::test_server_without_mock_data ... ok
test commands::edge_app_server::tests::test_server_should_serve_correct_mock_data ... ok
test commands::playlist::tests::test_delete_playlist_should_send_correct_request ... ok
test commands::playlist::tests::test_list_playlists_should_send_correct_request ... ok
test authentication::tests::test_verify_and_store_token_when_token_is_invalid ... ok
test authentication::tests::test_remove_token_should_remove_token_from_storage ... ok
test commands::edge_app::tests::test_promote_when_version_doesnt_exist_should_fail ... ok
test commands::edge_app::tests::test_update_entrypoint_if_needed_when_remote_entrypoint_is_none_and_manifest_is_not_none_should_update_remote ... ok
test commands::screen::tests::test_add_screen_should_send_correct_request ... ok
test commands::edge_app::tests::test_update_entrypoint_if_needed_when_remote_entrypoint_is_different_from_manifest_should_patch_remote ... ok
test commands::playlist::tests::test_append_asset_to_playlist_should_send_correct_request ... ok
test commands::screen::tests::test_get_screen_should_return_screen ... ok
test commands::edge_app::tests::test_set_setting_when_setting_doesnt_exist_should_fail ... ok
test commands::screen::tests::test_list_screens_should_return_correct_screen_list ... ok
test commands::screen::tests::test_delete_screen_should_send_correct_request ... ok
test commands::edge_app::tests::test_ensure_installation_id_when_app_id_in_manifest_and_installation_id_missing_and_old_name_installation_doesnt_exist_should_create_installation_and_save_installation_id_to_manifest ... ok
test commands::playlist::tests::test_create_playlist_should_send_correct_request ... ok
test commands::edge_app::tests::test_promote_should_send_correct_request ... ok
test commands::playlist::tests::test_get_playlist_file_should_send_correct_request_and_return_playlist_file ... ok
test commands::edge_app::tests::test_set_secrets_should_send_correct_request ... ok
test commands::edge_app::tests::test_set_global_secrets_should_send_correct_request ... ok
test commands::edge_app::tests::test_list_settings_should_send_correct_request ... ok
test commands::edge_app::tests::test_set_global_setting_when_setting_value_not_exists_should_send_correct_create_request ... ok
test commands::edge_app::tests::test_set_setting_when_setting_value_exists_should_send_correct_update_request ... ok
test commands::edge_app::tests::test_set_setting_should_send_correct_request ... ok
test commands::edge_app::tests::test_set_global_setting_when_setting_value_exists_should_send_correct_update_request ... ok
test commands::playlist::tests::test_update_playlist_should_send_correct_request ... ok
test commands::playlist::tests::test_prepend_asset_to_playlist_should_send_correct_request ... ok
test commands::edge_app::tests::test_upload_should_send_correct_requests ... ok

test result: ok. 115 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.66s
```
