### PR TITLE
Adds: env for overriding manifest file.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -835,11 +835,15 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                 commands::edge_app::EdgeAppCommand::create
             };
 
-            match create_func(
-                &edge_app_command,
-                name,
-                transform_edge_app_path_to_manifest(path).as_path(),
-            ) {
+            let manifest_path = match transform_edge_app_path_to_manifest(path) {
+                Ok(path) => path,
+                Err(e) => {
+                    eprintln!("Failed to create edge app: {e}.");
+                    std::process::exit(1);
+                }
+            };
+
+            match create_func(&edge_app_command, name, manifest_path.as_path()) {
                 Ok(()) => {
                     println!("Edge app successfully created.");
                 }
@@ -921,10 +925,17 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             match edge_app_command.delete_app(&actual_app_id) {
                 Ok(()) => {
                     println!("Edge App Deletion in Progress.\nRequest to delete the Edge App has been received and is now being processed. The deletion is marked for asynchronous handling, so it won't happen instantly.");
+
+                    let manifest_path = match transform_edge_app_path_to_manifest(path) {
+                        Ok(path) => path,
+                        Err(e) => {
+                            eprintln!("Failed to delete edge app: {e}.");
+                            std::process::exit(1);
+                        }
+                    };
+
                     // If the user didn't specify an app id, we need to clear it from the manifest
-                    match edge_app_command
-                        .clear_app_id(transform_edge_app_path_to_manifest(path).as_path())
-                    {
+                    match edge_app_command.clear_app_id(manifest_path.as_path()) {
                         Ok(()) => {
                             println!("App id cleared from manifest.");
                         }
@@ -971,7 +982,14 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             };
 
             if generate_mock_data.unwrap_or(false) {
-                let manifest_path = transform_edge_app_path_to_manifest(path);
+                let manifest_path = match transform_edge_app_path_to_manifest(path) {
+                    Ok(path) => path,
+                    Err(e) => {
+                        eprintln!("Failed to generate mock data: {e}.");
+                        std::process::exit(1);
+                    }
+                };
+
                 match edge_app_command.generate_mock_data(&manifest_path) {
                     Ok(_) => std::process::exit(0),
                     Err(e) => {
@@ -994,7 +1012,13 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
             edge_app_command.run(path.as_path(), secrets).unwrap();
         }
         EdgeAppCommands::Validate { path } => {
-            let manifest_path = transform_edge_app_path_to_manifest(path);
+            let manifest_path = match transform_edge_app_path_to_manifest(path) {
+                Ok(path) => path,
+                Err(e) => {
+                    eprintln!("Failed to validate manifest file: {e}.");
+                    std::process::exit(1);
+                }
+            };
             match EdgeAppManifest::ensure_manifest_is_valid(&manifest_path) {
                 Ok(()) => {
                     println!("Manifest file is valid.");
@@ -1112,14 +1136,17 @@ pub fn handle_cli_edge_app_command(command: &EdgeAppCommands) {
                         }
                     };
 
-                let instance_manifest_path: String =
-                    match transform_edge_app_path_to_manifest(path).to_str() {
-                        Some(path) => path.to_string(),
-                        None => {
-                            eprintln!(
-                                "Failed to create edge app instance. Path is not valid. {:?}",
-                                path
-                            );
+                let instance_manifest_path =
+                    match transform_instance_path_to_instance_manifest(path) {
+                        Ok(path) => match path.to_str() {
+                            Some(path) => path.to_string(),
+                            None => {
+                                eprintln!("Failed to delete edge app instance. Invalid path.");
+                                std::process::exit(1);
+                            }
+                        },
+                        Err(e) => {
+                            eprintln!("Failed to delete edge app instance. {:?}", e);
                             std::process::exit(1);
                         }
                     };
@@ -1191,7 +1218,7 @@ mod tests {
         let dir_path = dir.path().to_str().unwrap().to_string();
         let path = Some(dir_path.clone());
 
-        let new_path = transform_edge_app_path_to_manifest(&path);
+        let new_path = transform_edge_app_path_to_manifest(&path).unwrap();
 
         assert_eq!(
             new_path,
@@ -1207,7 +1234,7 @@ mod tests {
         // Change current directory to tempdir
         assert!(env::set_current_dir(dir_path).is_ok());
 
-        let new_path = transform_edge_app_path_to_manifest(&None);
+        let new_path = transform_edge_app_path_to_manifest(&None).unwrap();
 
         assert_eq!(new_path, dir_path.join("screenly.yml"));
     }

--- a/src/commands/edge_app/app.rs
+++ b/src/commands/edge_app/app.rs
@@ -185,7 +185,7 @@ impl EdgeAppCommand {
         path: Option<String>,
         delete_missing_settings: Option<bool>,
     ) -> Result<u32, CommandError> {
-        let manifest_path = transform_edge_app_path_to_manifest(&path);
+        let manifest_path = transform_edge_app_path_to_manifest(&path)?;
 
         EdgeAppManifest::ensure_manifest_is_valid(&manifest_path)?;
         let manifest = EdgeAppManifest::new(&manifest_path)?;
@@ -367,7 +367,7 @@ impl EdgeAppCommand {
     }
 
     pub fn update_entrypoint_value(&self, path: Option<String>) -> Result<(), CommandError> {
-        let manifest = EdgeAppManifest::new(&transform_edge_app_path_to_manifest(&path))?;
+        let manifest = EdgeAppManifest::new(&transform_edge_app_path_to_manifest(&path)?)?;
         let setting_key = "screenly_entrypoint";
 
         if let Some(entrypoint) = &manifest.entrypoint {
@@ -857,7 +857,7 @@ impl EdgeAppCommand {
     }
 
     pub fn get_app_id(&self, path: Option<String>) -> Result<String, CommandError> {
-        let edge_app_manifest = EdgeAppManifest::new(&transform_edge_app_path_to_manifest(&path))?;
+        let edge_app_manifest = EdgeAppManifest::new(&transform_edge_app_path_to_manifest(&path)?)?;
         match edge_app_manifest.id {
             Some(id) if !id.is_empty() => Ok(id),
             _ => Err(CommandError::MissingAppId),

--- a/src/commands/edge_app/utils.rs
+++ b/src/commands/edge_app/utils.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use walkdir::{DirEntry, WalkDir};
 
 const INSTANCE_FILE_NAME_ENV: &str = "INSTANCE_FILE_NAME";
+const MANIFEST_FILE_NAME_ENV: &str = "MANIFEST_FILE_NAME";
 
 #[derive(Debug, Clone)]
 pub struct EdgeAppFile {
@@ -72,14 +73,33 @@ fn is_included(entry: &DirEntry, ignore: &Ignorer) -> bool {
     return !ignore.is_ignored(entry.path());
 }
 
-pub fn transform_edge_app_path_to_manifest(path: &Option<String>) -> PathBuf {
+pub fn transform_edge_app_path_to_manifest(path: &Option<String>) -> Result<PathBuf, CommandError> {
+    let manifest_path = env::var(MANIFEST_FILE_NAME_ENV);
+
+    let filename = match manifest_path {
+        Ok(path) => {
+            let path_obj = Path::new(&path);
+            if path_obj.components().count() != 1 {
+                return Err(CommandError::ManifestFilenameError(path));
+            }
+            path
+        }
+        Err(_) => "screenly.yml".to_string(),
+    };
+
     let mut result = match path {
-        Some(path) => PathBuf::from(path),
+        Some(path) => {
+            let path_buf_obj = PathBuf::from(path);
+            if !path_buf_obj.is_dir() {
+                return Err(CommandError::PathIsNotDirError(path.clone()));
+            }
+            path_buf_obj
+        }
         None => env::current_dir().unwrap(),
     };
 
-    result.push("screenly.yml");
-    result
+    result.push(filename);
+    Ok(result)
 }
 
 pub fn transform_instance_path_to_instance_manifest(
@@ -1026,7 +1046,74 @@ mod tests {
         temp_env::with_var(INSTANCE_FILE_NAME_ENV, Some("folder/instance2.yml"), || {
             let result = transform_instance_path_to_instance_manifest(&None);
             assert!(result.is_err());
-            assert_eq!(result.unwrap_err().to_string(), "Env var INSTANCE_FILENAME must hold only file name, not a path. folder/instance2.yml");
+            assert_eq!(result.unwrap_err().to_string(), "Env var INSTANCE_FILE_NAME must hold only file name, not a path. folder/instance2.yml");
+        });
+    }
+
+    #[test]
+    fn test_transform_edge_app_path_to_manifest_should_return_current_dir_with_() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+        assert!(env::set_current_dir(dir_path).is_ok());
+
+        let result = transform_edge_app_path_to_manifest(&None);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), dir_path.join("screenly.yml"));
+    }
+
+    #[test]
+    fn test_transform_edge_app_path_to_manifest_when_path_provided_should_return_path_with_instance_manifest(
+    ) {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+        assert!(env::set_current_dir(dir_path).is_ok());
+
+        let dir2 = tempdir().unwrap();
+        let dir_path2 = dir2.path();
+
+        let result =
+            transform_edge_app_path_to_manifest(&Some(dir_path2.to_str().unwrap().to_string()));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), dir_path2.join("screenly.yml"));
+    }
+
+    #[test]
+    fn test_transform_edge_app_path_to_manifest_when_path_provided_is_not_a_dir_should_fail() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+        assert!(env::set_current_dir(dir_path).is_ok());
+
+        let result = transform_edge_app_path_to_manifest(&Some("screenly2.yml".to_string()));
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Path is not a directory: screenly2.yml"
+        );
+    }
+
+    #[test]
+    fn test_transform_edge_app_path_to_manifest_with_env_instance_override_should_return_overrided_manifest_path(
+    ) {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+        assert!(env::set_current_dir(dir_path).is_ok());
+        temp_env::with_var(MANIFEST_FILE_NAME_ENV, Some("screenly2.yml"), || {
+            let result = transform_edge_app_path_to_manifest(&None);
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), dir_path.join("screenly2.yml"));
+        });
+    }
+
+    #[test]
+    fn test_transform_edge_app_path_to_manifest_with_env_path_instead_of_file_should_fail() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+        assert!(env::set_current_dir(dir_path).is_ok());
+
+        temp_env::with_var(MANIFEST_FILE_NAME_ENV, Some("folder/screenly2.yml"), || {
+            let result = transform_edge_app_path_to_manifest(&None);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().to_string(), "Env var MANIFEST_FILE_NAME must hold only file name, not a path. folder/screenly2.yml");
         });
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -120,8 +120,10 @@ pub enum CommandError {
     OpenBrowserError(String),
     #[error("Instance already exists")]
     InstanceAlreadyExists,
-    #[error("Env var INSTANCE_FILENAME must hold only file name, not a path. {0}")]
+    #[error("Env var INSTANCE_FILE_NAME must hold only file name, not a path. {0}")]
     InstanceFilenameError(String),
+    #[error("Env var MANIFEST_FILE_NAME must hold only file name, not a path. {0}")]
+    ManifestFilenameError(String),
     #[error("Path is not a directory: {0}")]
     PathIsNotDirError(String),
     #[error("Missing installation id in the instance file")]


### PR DESCRIPTION
Adds: MANIFEST_FILE_NAME env to override screenly.yml manifest file.
