### PR TITLE
Adds: ability to set debug logger level for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ glob = "0.3.1"
 hex = "0.4.3"
 http-auth-basic = "0.3.3"
 indicatif = "0.17.2"
-log = { version = "0.4.17", features = ["release_max_level_info", "max_level_debug"] }
+log = { version = "0.4.17", features = ["release_max_level_debug", "max_level_debug"] }
 openssl = { version = '0.10', features = ["vendored"] }
 prettytable-rs = "0.10.0"
 protobuf = "3.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,23 @@ extern crate prettytable;
 
 use crate::authentication::{Authentication, AuthenticationError};
 use clap::Parser;
-use simple_logger::SimpleLogger;
+use simple_logger::{init_with_env, SimpleLogger};
+
+use std::env;
 
 fn main() {
-    SimpleLogger::new().init().unwrap();
+    if env::var("RUST_LOG").is_ok() {
+        init_with_env().unwrap();
+    } else {
+        let log_level = {
+            if cfg!(debug_assertions) {
+                log::LevelFilter::Debug
+            } else {
+                log::LevelFilter::Info
+            }
+        };
+        SimpleLogger::new().with_level(log_level).init().unwrap();
+    }
 
     let _sentry_dsn = "https://891eb4b6f8ff4f959fd76a587d9ab302@o4505481987489792.ingest.sentry.io/4505482139140096";
 


### PR DESCRIPTION
Now debug calls are not stripped from release version, which in our case seems fine.

For release build INFO level is still a default, but could be overrdriven by default env var.
RUST_LOG is expected env for the log library, so no reason to replace it with our implementation --log-level or smth else.

`RUST_LOG=debug ../target/release/screenly edge-app list`