### PR TITLE
Adds: release 1.0.1 including debug logs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,7 +2333,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screenly"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screenly"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3 as builder
 
 WORKDIR /usr/src/screenly-cli
 RUN apk add --no-cache wget tar
-ARG RELEASE=v1.0.0
+ARG RELEASE=v1.0.1
 RUN wget "https://github.com/Screenly/cli/releases/download/$RELEASE/screenly-cli-x86_64-unknown-linux-musl.tar.gz"
 RUN tar xfz screenly-cli-x86_64-unknown-linux-musl.tar.gz
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   cli_version:
     description: "Screenly CLI version."
-    default: "v1.0.0"
+    default: "v1.0.1"
 outputs:
   cli_commands_response:
     description: "The response from the Screenly CLI command(s)."


### PR DESCRIPTION
Minor 1.0.1 release with debug logs accessible in release build via RUST_LOG=debug env var.