### PR TITLE
Fix windows browser open command

### DIFF
--- a/src/commands/edge_app/server.rs
+++ b/src/commands/edge_app/server.rs
@@ -258,10 +258,10 @@ impl EdgeAppCommand {
     }
 
     fn open_browser(&self, address: &str) -> Result<(), CommandError> {
-        let command = match std::env::consts::OS {
-            "macos" => "open",
-            "windows" => "start",
-            "linux" => "xdg-open",
+        let (command, args) = match std::env::consts::OS {
+            "macos" => ("open", vec![address]),
+            "windows" => ("cmd", vec!["/C", "start", "", address]),
+            "linux" => ("xdg-open", vec![address]),
             _ => {
                 return Err(CommandError::OpenBrowserError(
                     "Unsupported OS to open browser".to_string(),
@@ -270,14 +270,14 @@ impl EdgeAppCommand {
         };
 
         let output = std::process::Command::new(command)
-            .arg(address)
+            .args(&args)
             .output()
             .expect("Failed to open browser");
 
         if !output.status.success() {
             return Err(CommandError::OpenBrowserError(format!(
                 "Failed to open browser: {}",
-                str::from_utf8(&output.stderr).unwrap()
+                std::str::from_utf8(&output.stderr).unwrap()
             )));
         }
 

--- a/src/commands/edge_app/utils.rs
+++ b/src/commands/edge_app/utils.rs
@@ -70,7 +70,7 @@ fn is_included(entry: &DirEntry, ignore: &Ignorer) -> bool {
         return false;
     }
 
-    return !ignore.is_ignored(entry.path());
+    !ignore.is_ignored(entry.path())
 }
 
 pub fn transform_edge_app_path_to_manifest(path: &Option<String>) -> Result<PathBuf, CommandError> {


### PR DESCRIPTION
Fixes browser failing to start on Windows due to incorrect 'start' command usage.
