### PR TITLE
fix: serve JavaScript with correct MIME type in edge-app run

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     name: List screens
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: list-screens
-        uses: ./
+        uses: screenly/cli@master
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
           cli_commands: screen list

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: list-screens
-        uses: screenly/cli@master
+        uses: ./
         with:
           screenly_api_token: ${{ secrets.SCREENLY_API_TOKEN }}
           cli_commands: screen list

--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ fn main() {
     };
     fs::write(
         dest_path,
-        format!("pub const API_BASE_URL: &str = \"{}\";", api_server),
+        format!("pub const API_BASE_URL: &str = \"{api_server}\";"),
     )
     .unwrap();
     println!("cargo:rerun-if-changed=build.rs");

--- a/src/commands/edge_app/server.rs
+++ b/src/commands/edge_app/server.rs
@@ -141,7 +141,11 @@ async fn generate_content(
 
     let js_output = format_js(data, secrets);
 
-    Ok(warp::reply::html(js_output))
+    Ok(warp::reply::with_header(
+        js_output,
+        "content-type",
+        "application/javascript",
+    ))
 }
 
 fn format_js(data: MockData, secrets: &[(String, Value)]) -> String {
@@ -429,6 +433,26 @@ settings:
             .unwrap();
 
         assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn test_server_should_serve_javascript_with_correct_mime_type() {
+        let dir = setup_temp_dir_with_mock_data();
+        let dir_path = dir.path().to_path_buf();
+
+        let address = run_server(&dir_path, vec![("key".to_string(), "value".to_string())])
+            .await
+            .unwrap();
+        let resp = reqwest::get(format!("{}/screenly.js?version=1", address))
+            .await
+            .unwrap();
+
+        // Verify the response is successful
+        assert_eq!(resp.status(), 200);
+
+        // Verify the Content-Type header is correct
+        let content_type = resp.headers().get("content-type").unwrap();
+        assert_eq!(content_type, "application/javascript");
     }
 
     #[test]


### PR DESCRIPTION
The screenly.js file was being served with text/html Content-Type instead of application/javascript, causing browser console errors. This change:

- Updates server.rs to use application/javascript MIME type
- Adds test to verify correct Content-Type header is returned
- Fixes format string linting issue in build.rs

Resolves JavaScript MIME type console error in edge-app emulator.

## What does this PR do?

## GitHub issue or Phabricator ticket number?

#250

## How has this been tested?

I have tested this locally and can confirm that the error is no longer visible in the console.log().
 
## Checklist before merging

- [x] If have added tests.