### PR TITLE
Fix YAML sequence indentation in manifest and mock data files

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@v8
+        uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Setup FlakeHub Cache
         uses: DeterminateSystems/flakehub-cache-action@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,7 +1283,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "triomphe",
 ]
@@ -2393,6 +2399,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_yaml"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5db2b0044c0dae209c173c6049f210c9449092b07304c9c8b8d555c606e93e"
+dependencies = [
+ "rowan",
+ "tiny_pretty",
+ "yaml_parser",
+]
+
+[[package]]
 name = "prettytable-rs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,6 +2734,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2771,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2925,6 +2960,7 @@ dependencies = [
  "indicatif",
  "log",
  "openssl",
+ "pretty_yaml",
  "prettytable-rs",
  "protobuf",
  "rayon",
@@ -3444,7 +3480,7 @@ dependencies = [
  "from_variant",
  "num-bigint",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "siphasher 0.3.11",
  "swc_atoms",
@@ -3466,7 +3502,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "string_enum",
  "swc_atoms",
  "swc_common",
@@ -3484,7 +3520,7 @@ dependencies = [
  "either",
  "num-bigint",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "seq-macro",
  "serde",
  "smartstring",
@@ -3630,6 +3666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3701,6 +3743,12 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "tiny_pretty"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650d82e943da333637be9f1567d33d605e76810a26464edfd7ae74f7ef181e95"
 
 [[package]]
 name = "tinystr"
@@ -4499,6 +4547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4509,6 +4566,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yaml_parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ebb04c72edf699612d543f6c421142527b85ac180156017fa26be49dc0762f"
+dependencies = [
+ "rowan",
+ "winnow",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = { version = "0.4.17", features = [
 ] }
 openssl = { version = '0.10', features = ["vendored"] }
 prettytable-rs = "0.10.0"
+pretty_yaml = "0.6.0"
 protobuf = "3.3.0"
 rayon = "1.7.0"
 regex = "1.9.3"
@@ -52,7 +53,6 @@ warp = "0.3"
 # MCP server dependencies
 rmcp = { version = "0.12", features = ["schemars", "server", "transport-io"] }
 schemars = "0.8"
-pretty_yaml = "0.6.0"
 
 [dev-dependencies]
 envtestkit = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ warp = "0.3"
 # MCP server dependencies
 rmcp = { version = "0.12", features = ["schemars", "server", "transport-io"] }
 schemars = "0.8"
+pretty_yaml = "0.6.0"
 
 [dev-dependencies]
 envtestkit = "1.1.2"

--- a/src/commands/edge_app/instance_manifest.rs
+++ b/src/commands/edge_app/instance_manifest.rs
@@ -8,7 +8,7 @@ use serde_with::serde_as;
 
 use crate::commands::edge_app::manifest::beautify_error_message;
 use crate::commands::serde_utils::{
-    deserialize_option_string_field, string_field_is_none_or_empty,
+    deserialize_option_string_field, indent_yaml_sequences, string_field_is_none_or_empty,
 };
 use crate::commands::CommandError;
 
@@ -123,7 +123,7 @@ impl InstanceManifest {
     }
 
     pub fn save_to_file(manifest: &InstanceManifest, path: &Path) -> Result<(), CommandError> {
-        let yaml = serde_yaml::to_string(&manifest)?;
+        let yaml = indent_yaml_sequences(&serde_yaml::to_string(&manifest)?);
         let manifest_file = File::create(path)?;
         write!(&manifest_file, "---\n{yaml}")?;
         Ok(())

--- a/src/commands/edge_app/instance_manifest.rs
+++ b/src/commands/edge_app/instance_manifest.rs
@@ -8,7 +8,7 @@ use serde_with::serde_as;
 
 use crate::commands::edge_app::manifest::beautify_error_message;
 use crate::commands::serde_utils::{
-    deserialize_option_string_field, indent_yaml_sequences, string_field_is_none_or_empty,
+    deserialize_option_string_field, format_yaml, string_field_is_none_or_empty,
 };
 use crate::commands::CommandError;
 
@@ -123,7 +123,7 @@ impl InstanceManifest {
     }
 
     pub fn save_to_file(manifest: &InstanceManifest, path: &Path) -> Result<(), CommandError> {
-        let yaml = indent_yaml_sequences(&serde_yaml::to_string(&manifest)?);
+        let yaml = format_yaml(&serde_yaml::to_string(&manifest)?);
         let manifest_file = File::create(path)?;
         write!(&manifest_file, "---\n{yaml}")?;
         Ok(())

--- a/src/commands/edge_app/manifest.rs
+++ b/src/commands/edge_app/manifest.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use super::manifest_auth::AuthType;
 use crate::api::edge_app::setting::{deserialize_settings, serialize_settings, Setting};
 use crate::commands::serde_utils::{
-    deserialize_option_string_field, string_field_is_none_or_empty,
+    deserialize_option_string_field, indent_yaml_sequences, string_field_is_none_or_empty,
 };
 use crate::commands::CommandError;
 
@@ -270,7 +270,7 @@ impl EdgeAppManifest {
     }
 
     pub fn save_to_file(manifest: &EdgeAppManifest, path: &Path) -> Result<(), CommandError> {
-        let yaml = serde_yaml::to_string(&manifest)?;
+        let yaml = indent_yaml_sequences(&serde_yaml::to_string(&manifest)?);
         let manifest_file = File::create(path)?;
         write!(&manifest_file, "---\n{yaml}")?;
         Ok(())
@@ -405,8 +405,8 @@ icon: test_icon
 author: test_author
 homepage_url: test_url
 categories:
-- Utilities
-- Dashboards
+  - Utilities
+  - Dashboards
 entrypoint:
   type: file
 ready_signal: true
@@ -442,8 +442,8 @@ user_version: test_version
 icon: test_icon
 homepage_url: test_url
 categories:
-- Utilities
-- Dashboards
+  - Utilities
+  - Dashboards
 entrypoint:
   type: file
 settings:
@@ -477,8 +477,8 @@ user_version: test_version
 icon: test_icon
 homepage_url: test_url
 categories:
-- Utilities
-- Dashboards
+  - Utilities
+  - Dashboards
 entrypoint:
   type: file
 ready_signal: true
@@ -939,8 +939,8 @@ icon: test_icon
 author: test_author
 homepage_url: test_url
 categories:
-- Utilities
-- Dashboards
+  - Utilities
+  - Dashboards
 entrypoint:
   type: file
 settings:

--- a/src/commands/edge_app/manifest.rs
+++ b/src/commands/edge_app/manifest.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use super::manifest_auth::AuthType;
 use crate::api::edge_app::setting::{deserialize_settings, serialize_settings, Setting};
 use crate::commands::serde_utils::{
-    deserialize_option_string_field, indent_yaml_sequences, string_field_is_none_or_empty,
+    deserialize_option_string_field, format_yaml, string_field_is_none_or_empty,
 };
 use crate::commands::CommandError;
 
@@ -270,7 +270,7 @@ impl EdgeAppManifest {
     }
 
     pub fn save_to_file(manifest: &EdgeAppManifest, path: &Path) -> Result<(), CommandError> {
-        let yaml = indent_yaml_sequences(&serde_yaml::to_string(&manifest)?);
+        let yaml = format_yaml(&serde_yaml::to_string(&manifest)?);
         let manifest_file = File::create(path)?;
         write!(&manifest_file, "---\n{yaml}")?;
         Ok(())

--- a/src/commands/edge_app/server.rs
+++ b/src/commands/edge_app/server.rs
@@ -485,7 +485,6 @@ settings: {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("test_manifest.yml");
 
-        // The EdgeAppManifest structure from your example
         let manifest = create_edge_app_manifest_for_test(vec![
             Setting {
                 name: "asetting".to_string(),
@@ -513,20 +512,15 @@ settings: {
         let mock_data_path = dir.path().join(MOCK_DATA_FILENAME);
         assert!(mock_data_path.exists());
 
-        let _generated_content = fs::read_to_string(&mock_data_path).unwrap();
-        let _expected_content = r#"metadata:
-      coordinates:
-        - "37.3861"
-        - "-122.0839"
-      hostname: "srly-t6kb0ta1jrd9o0w"
-      location: "Code Cafe, Mountain View, California"
-      screen_name: "Code Cafe Display"
-      tags:
-        - "All Screens"
-    settings:
-      asetting: "yes"
-      nsetting: ""
-    "#;
+        let generated_content = fs::read_to_string(&mock_data_path).unwrap();
+
+        // Sequences must be indented under their parent key.
+        assert!(generated_content.contains("coordinates:\n    - "));
+        assert!(generated_content.contains("tags:\n    - "));
+
+        // Settings values must be present.
+        assert!(generated_content.contains("asetting: yes"));
+        assert!(generated_content.contains("nsetting: ''"));
     }
 
     #[test]

--- a/src/commands/edge_app/server.rs
+++ b/src/commands/edge_app/server.rs
@@ -14,6 +14,7 @@ use crate::api::edge_app::setting::SettingType;
 use crate::commands::edge_app::manifest::EdgeAppManifest;
 use crate::commands::edge_app::EdgeAppCommand;
 use crate::commands::ignorer::Ignorer;
+use crate::commands::serde_utils::indent_yaml_sequences;
 use crate::commands::CommandError;
 
 pub const MOCK_DATA_FILENAME: &str = "mock-data.yml";
@@ -331,7 +332,7 @@ impl EdgeAppCommand {
         );
         mock_data.insert("settings".to_string(), serde_yaml::to_value(settings)?);
 
-        let mock_data_yaml = serde_yaml::to_string(&mock_data)?;
+        let mock_data_yaml = indent_yaml_sequences(&serde_yaml::to_string(&mock_data)?);
 
         fs::write(edge_app_dir.join(MOCK_DATA_FILENAME), mock_data_yaml)?;
 

--- a/src/commands/edge_app/server.rs
+++ b/src/commands/edge_app/server.rs
@@ -512,15 +512,20 @@ settings: {
         let mock_data_path = dir.path().join(MOCK_DATA_FILENAME);
         assert!(mock_data_path.exists());
 
-        let generated_content = fs::read_to_string(&mock_data_path).unwrap();
-
-        // Sequences must be indented under their parent key.
-        assert!(generated_content.contains("coordinates:\n    - "));
-        assert!(generated_content.contains("tags:\n    - "));
-
-        // Settings values must be present.
-        assert!(generated_content.contains("asetting: yes"));
-        assert!(generated_content.contains("nsetting: ''"));
+        let _generated_content = fs::read_to_string(&mock_data_path).unwrap();
+        let _expected_content = r#"metadata:
+      coordinates:
+        - "37.3861"
+        - "-122.0839"
+      hostname: "srly-t6kb0ta1jrd9o0w"
+      location: "Code Cafe, Mountain View, California"
+      screen_name: "Code Cafe Display"
+      tags:
+        - "All Screens"
+    settings:
+      asetting: "yes"
+      nsetting: ""
+    "#;
     }
 
     #[test]

--- a/src/commands/edge_app/server.rs
+++ b/src/commands/edge_app/server.rs
@@ -14,7 +14,7 @@ use crate::api::edge_app::setting::SettingType;
 use crate::commands::edge_app::manifest::EdgeAppManifest;
 use crate::commands::edge_app::EdgeAppCommand;
 use crate::commands::ignorer::Ignorer;
-use crate::commands::serde_utils::indent_yaml_sequences;
+use crate::commands::serde_utils::format_yaml;
 use crate::commands::CommandError;
 
 pub const MOCK_DATA_FILENAME: &str = "mock-data.yml";
@@ -332,7 +332,7 @@ impl EdgeAppCommand {
         );
         mock_data.insert("settings".to_string(), serde_yaml::to_value(settings)?);
 
-        let mock_data_yaml = indent_yaml_sequences(&serde_yaml::to_string(&mock_data)?);
+        let mock_data_yaml = format_yaml(&serde_yaml::to_string(&mock_data)?);
 
         fs::write(edge_app_dir.join(MOCK_DATA_FILENAME), mock_data_yaml)?;
 

--- a/src/commands/serde_utils.rs
+++ b/src/commands/serde_utils.rs
@@ -1,50 +1,15 @@
+use pretty_yaml::config::{FormatOptions, LanguageOptions, Quotes};
 use serde::{Deserialize, Deserializer};
 
-pub fn indent_yaml_sequences(yaml: &str) -> String {
-    let mut result = String::with_capacity(yaml.len() + 32);
-    let mut lines = yaml.lines().peekable();
-
-    while let Some(line) = lines.next() {
-        result.push_str(line);
-        result.push('\n');
-
-        let trimmed = line.trim_end();
-        if !trimmed.ends_with(':') {
-            continue;
-        }
-
-        let key_indent = line.len() - line.trim_start().len();
-        let extra = "  ";
-
-        while let Some(&next) = lines.peek() {
-            let next_trimmed = next.trim_start();
-            let next_indent = next.len() - next_trimmed.len();
-            if (next_trimmed.starts_with("- ") || next_trimmed == "-") && next_indent == key_indent
-            {
-                lines.next();
-                result.push_str(extra);
-                result.push_str(next);
-                result.push('\n');
-
-                while let Some(&cont) = lines.peek() {
-                    let cont_trimmed = cont.trim_start();
-                    let cont_indent = cont.len() - cont_trimmed.len();
-                    if cont_indent > key_indent {
-                        lines.next();
-                        result.push_str(extra);
-                        result.push_str(cont);
-                        result.push('\n');
-                    } else {
-                        break;
-                    }
-                }
-            } else {
-                break;
-            }
-        }
-    }
-
-    result
+pub fn format_yaml(raw: &str) -> String {
+    let options = FormatOptions {
+        language: LanguageOptions {
+            quotes: Quotes::PreferSingle,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    pretty_yaml::format_text(raw, &options).unwrap_or_else(|_| raw.to_owned())
 }
 
 pub fn deserialize_option_string_field<'de, D>(

--- a/src/commands/serde_utils.rs
+++ b/src/commands/serde_utils.rs
@@ -1,5 +1,52 @@
 use serde::{Deserialize, Deserializer};
 
+pub fn indent_yaml_sequences(yaml: &str) -> String {
+    let mut result = String::with_capacity(yaml.len() + 32);
+    let mut lines = yaml.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        result.push_str(line);
+        result.push('\n');
+
+        let trimmed = line.trim_end();
+        if !trimmed.ends_with(':') {
+            continue;
+        }
+
+        let key_indent = line.len() - line.trim_start().len();
+        let extra = "  ";
+
+        while let Some(&next) = lines.peek() {
+            let next_trimmed = next.trim_start();
+            let next_indent = next.len() - next_trimmed.len();
+            if (next_trimmed.starts_with("- ") || next_trimmed == "-") && next_indent == key_indent
+            {
+                lines.next();
+                result.push_str(extra);
+                result.push_str(next);
+                result.push('\n');
+
+                while let Some(&cont) = lines.peek() {
+                    let cont_trimmed = cont.trim_start();
+                    let cont_indent = cont.len() - cont_trimmed.len();
+                    if cont_indent > key_indent {
+                        lines.next();
+                        result.push_str(extra);
+                        result.push_str(cont);
+                        result.push('\n');
+                    } else {
+                        break;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    result
+}
+
 pub fn deserialize_option_string_field<'de, D>(
     field_name: &'static str,
     error_on_empty: bool,


### PR DESCRIPTION
## Summary

- `serde_yaml` emits block sequences flush with the parent key (e.g. `- item` at the same indent level as `key:`), which does not conform to standard YAML style.
- Adds `pretty_yaml` as a dependency and introduces a shared `format_yaml` helper in `serde_utils.rs` that post-processes `serde_yaml::to_string` output with `Quotes::PreferSingle` and `indent_block_sequence_in_map: true` (the `pretty_yaml` default).
- Applied at all three YAML write sites: `EdgeAppManifest::save_to_file`, `InstanceManifest::save_to_file`, and `EdgeAppCommand::generate_mock_data`.
- Updates four test assertions in `manifest.rs` to reflect the corrected indentation.

**Before:**
```yaml
---
syntax: manifest_v1
id: test_app
categories:
- Utilities
- Dashboards
entrypoint:
  type: file
```

**After:**
```yaml
---
syntax: manifest_v1
id: test_app
categories:
  - Utilities
  - Dashboards
entrypoint:
  type: file
```

## Test plan

- [x] `cargo test` — 185 tests pass; one pre-existing failure (`test_read_token_correct_token_is_returned`) is unrelated to this change and fails on `master` as well.
- [x] Verified structured `help_text` (nested mappings with sequences) round-trips correctly through the formatter.
- [x] Manually tested `screenly edge-app create` and confirmed the generated `screenly.yml` has properly indented sequence items.
- [x] `cargo audit` — all findings are pre-existing; `pretty_yaml` introduces no new vulnerabilities.