### PR TITLE
Add arm64 and armhf binaries to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,14 @@ jobs:
             os: ubuntu-22.04
             rust: stable
             target: x86_64-unknown-linux-musl
+          - build: linux-arm64
+            os: ubuntu-22.04
+            rust: stable
+            target: aarch64-unknown-linux-gnu
+          - build: linux-armhf
+            os: ubuntu-22.04
+            rust: stable
+            target: armv7-unknown-linux-gnueabihf
           - build: macos
             os: macos-15
             rust: stable


### PR DESCRIPTION
## What

Adds two Linux ARM targets to the release build matrix in `.github/workflows/release.yml`:

- **arm64** → `aarch64-unknown-linux-gnu`
- **armhf** → `armv7-unknown-linux-gnueabihf` (standard Debian hardfloat / ARMv7)

These produce `screenly-cli-aarch64-unknown-linux-gnu.tar.gz` and `screenly-cli-armv7-unknown-linux-gnueabihf.tar.gz` release assets.

## Why

Provide prebuilt binaries for ARM hosts (e.g. arm64 servers, ARMv7 devices) so users don't have to build from source.

## Notes

- The existing workflow already uses `cross` for every Linux target, so these slot in with no other changes needed.
- Binaries are **not stripped** — the `strip` step only runs for the x86_64 `linux` and `macos` builds. This matches the existing `linux-musl` behavior.
- armhf is `armv7-unknown-linux-gnueabihf` (ARMv7). If ARMv6 (Pi Zero / Pi 1) support is needed, that would be a separate `arm-unknown-linux-gnueabihf` target.

## Testing

Verified locally with `cross` (matching CI's `cargo install cross`):

- `cross build --release --target aarch64-unknown-linux-gnu` ✅
- `cross build --release --target armv7-unknown-linux-gnueabihf` ✅ (incl. vendored OpenSSL C build per arch)
- `file` confirmed correct architectures (ARM aarch64 64-bit; ARM 32-bit EABI5 hardfloat)
- Reproduced the `tar czvf` packaging step — both archives build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)