### PR TITLE
Harden CI supply chain and add grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Cargo: security updates only, bundled into a single PR.
+  #
+  # This repo does not take routine version bumps -- `open-pull-requests-limit: 0`
+  # disables version updates while leaving Dependabot security updates enabled.
+  # Without the group below, each advisory opens its own PR (see #280, #283,
+  # #288, #289, #290, all of which sat open for months after the underlying
+  # bumps had already landed).
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions: group both version and security updates into one PR each.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: List screens
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - id: list-screens
         uses: screenly/cli@master
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,10 +43,10 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add x86_64-unknown-linux-gnu
 
       - name: Generate documentation
         run: cargo run -- print-help-markdown > /tmp/CommandLineHelp.md

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,8 @@ jobs:
       docs_command_line_help: ${{ steps.filter.outputs.docs_command_line_help }}
       docs_edge_apps: ${{ steps.filter.outputs.docs_edge_apps }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           list-files: shell
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
           target: x86_64-unknown-linux-gnu

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly
         with:
           components: rustfmt
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -16,9 +16,8 @@ jobs:
         with:
           submodules: recursive
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly
-        with:
-          components: rustfmt
+      - name: Install rustfmt
+        run: rustup component add rustfmt
 
       - name: Run rustfmt check
         id: fmt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,4 +37,4 @@ jobs:
         run: rustup component add clippy
 
       - name: Run clippy
-        run: cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings
+        run: cargo clippy --manifest-path Cargo.toml --all-targets

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,4 +37,4 @@ jobs:
         run: rustup component add clippy
 
       - name: Run clippy
-        run: cargo clippy --manifest-path Cargo.toml --all-targets
+        run: cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,17 +7,17 @@ on:
     paths:
       - "**.rs"
       - "Cargo.toml"
+      - ".github/workflows/lint.yml"
   pull_request:
     branches:
       - master
     paths:
       - "**.rs"
       - "Cargo.toml"
+      - ".github/workflows/lint.yml"
 
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
 
 jobs:
   lint:
@@ -33,8 +33,8 @@ jobs:
       - name: Install dependencies
         run: sudo apt  -q -yy install libdbus-1-dev pkg-config libdbus-1-3 libsystemd0 libsystemd-dev
 
-      - name: rust-clippy-check
-        uses: actions-rs/clippy-check@v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path Cargo.toml
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Run clippy
+        run: cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,7 +39,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Setup FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@3be0931021788e3bb4df65f59a555039c2fa2d46 # main
+        uses: DeterminateSystems/flakehub-cache-action@3be0931021788e3bb4df65f59a555039c2fa2d46 # v3.21.7
 
       - name: Build screenly-cli
         run: nix build .#screenly-cli

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -33,13 +33,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout flake
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Setup FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@3be0931021788e3bb4df65f59a555039c2fa2d46 # main
 
       - name: Build screenly-cli
         run: nix build .#screenly-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,10 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal
+          rustup default ${{ matrix.rust }}
+          rustup target add ${{ matrix.target }}
 
       - name: Use Cross
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
         run: |
@@ -106,7 +106,7 @@ jobs:
           cd -
 
       - name: Publish
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         # TODO: if any of the build step fails, the release should be deleted.
         with:
           files: "screenly*"
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build container
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
@@ -106,7 +106,7 @@ jobs:
           cd -
 
       - name: Publish
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         # TODO: if any of the build step fails, the release should be deleted.
         with:
           files: "screenly*"
@@ -114,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attest
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
           subject-path: "${{ github.workspace }}/screenly*"
 
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Build container
         run: |
@@ -141,7 +141,7 @@ jobs:
 
       - name: Login to DockerHub
         if: success() && github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Cache Cargo & target directories
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Upload SBOM
-        uses: sbomify/github-action@e7848bb19cfcd770b8f06b985603cdd0ec0e0be2 # master
+        uses: sbomify/github-action@ddf6a0d3d75b645153ad1ad60034b3fe2cb1eb63 # v26.7.0
         env:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: 'UUzAdk8ixV'

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -14,10 +14,10 @@ jobs:
       attestations: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Upload SBOM
-        uses: sbomify/github-action@master
+        uses: sbomify/github-action@e7848bb19cfcd770b8f06b985603cdd0ec0e0be2 # master
         env:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: 'UUzAdk8ixV'
@@ -29,6 +29,6 @@ jobs:
           ENRICH: true
 
       - name: Attest
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
           subject-path: '${{ github.workspace }}/cli.cdx.json'

--- a/src/api/edge_app/setting.rs
+++ b/src/api/edge_app/setting.rs
@@ -329,7 +329,7 @@ impl Api {
         payload.insert("app_id".to_owned(), json!(app_id));
         payload.insert("name".to_owned(), json!(setting.name));
 
-        debug!("Creating setting: {:?}", &payload);
+        debug!("Creating setting: {:?}", payload);
         commands::post(&self.authentication, "v4.1/edge-apps/settings", &payload)
     }
 
@@ -338,7 +338,7 @@ impl Api {
         let mut payload = serde_json::from_value::<HashMap<String, serde_json::Value>>(value)?;
         payload.insert("name".to_owned(), json!(setting.name));
 
-        debug!("Updating setting: {:?}", &payload);
+        debug!("Updating setting: {:?}", payload);
 
         commands::patch(
             &self.authentication,

--- a/src/commands/asset.rs
+++ b/src/commands/asset.rs
@@ -57,7 +57,7 @@ impl AssetCommand {
     }
 
     pub fn add(&self, path: &str, title: &str) -> anyhow::Result<Assets, CommandError> {
-        let url = format!("{}/v4/assets", &self.authentication.config.url);
+        let url = format!("{}/v4/assets", self.authentication.config.url);
 
         let mut headers = HeaderMap::new();
         headers.insert("Prefer", "return=representation".parse()?);
@@ -130,7 +130,7 @@ impl AssetCommand {
             }
             let headers = assets[0].get("headers").ok_or(CommandError::MissingField)?;
             let old_headers = serde_json::from_value::<HashMap<String, String>>(headers.clone())?;
-            debug!("Old headers {:?}", &old_headers);
+            debug!("Old headers {:?}", old_headers);
             for (key, value) in old_headers {
                 new_headers.entry(key).or_insert(value);
             }

--- a/src/commands/edge_app/app.rs
+++ b/src/commands/edge_app/app.rs
@@ -252,7 +252,7 @@ impl EdgeAppCommand {
             .api
             .get_version_asset_signatures(&actual_app_id, revision)?;
         let changed_files = detect_changed_files(&local_files, &remote_files)?;
-        debug!("Changed files: {:?}", &changed_files);
+        debug!("Changed files: {:?}", changed_files);
 
         let remote_settings = self.api.get_settings(&actual_app_id)?;
 
@@ -421,7 +421,7 @@ impl EdgeAppCommand {
             }
             debug!(
                 "ensure_assets_processing_finished: {:?}",
-                &asset_processing_statuses
+                asset_processing_statuses
             );
 
             for asset_processing_status in &asset_processing_statuses {
@@ -554,7 +554,7 @@ impl EdgeAppCommand {
         setting: &Setting,
         prompt_user: bool,
     ) -> Result<(), CommandError> {
-        debug!("Deleting setting: {:?}", &setting.name);
+        debug!("Deleting setting: {:?}", setting.name);
 
         let mut input_name = String::new();
 
@@ -627,7 +627,7 @@ impl EdgeAppCommand {
         path: &Path,
         _pb: &Arc<Mutex<ProgressBar>>,
     ) -> Result<(), CommandError> {
-        let url = format!("{}/v4/assets", &self.api.authentication.config.url);
+        let url = format!("{}/v4/assets", self.api.authentication.config.url);
 
         let mut headers = HeaderMap::new();
         headers.insert("Prefer", "return=representation".parse()?);
@@ -659,7 +659,7 @@ impl EdgeAppCommand {
 
         let status = response.status();
         if status != StatusCode::CREATED {
-            debug!("Response: {:?}", &response.text());
+            debug!("Response: {:?}", response.text());
             return Err(CommandError::WrongResponseStatus(status.as_u16()));
         }
 

--- a/src/commands/edge_app/utils.rs
+++ b/src/commands/edge_app/utils.rs
@@ -273,7 +273,7 @@ pub fn generate_file_tree(files: &[EdgeAppFile], root_path: &Path) -> HashMap<St
         tree.insert(relative_path.to_owned(), file.signature.clone());
     }
 
-    debug!("File tree: {:?}", &tree);
+    debug!("File tree: {:?}", tree);
 
     tree
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -174,7 +174,7 @@ pub fn get(
     authentication: &Authentication,
     endpoint: &str,
 ) -> Result<serde_json::Value, CommandError> {
-    let url = format!("{}/{}", &authentication.config.url, endpoint);
+    let url = format!("{}/{}", authentication.config.url, endpoint);
     debug!("GET {url}");
     let mut headers = HeaderMap::new();
     headers.insert("Prefer", "return=representation".parse()?);
@@ -189,7 +189,7 @@ pub fn get(
     debug!("GET {url} -> {status}");
 
     if status != StatusCode::OK {
-        println!("Response: {:?}", &response.text());
+        println!("Response: {:?}", response.text());
         return Err(CommandError::WrongResponseStatus(status.as_u16()));
     }
     Ok(serde_json::from_str(&response.text()?)?)
@@ -200,7 +200,7 @@ pub fn post<T: Serialize + ?Sized>(
     endpoint: &str,
     payload: &T,
 ) -> Result<serde_json::Value, CommandError> {
-    let url = format!("{}/{}", &authentication.config.url, endpoint);
+    let url = format!("{}/{}", authentication.config.url, endpoint);
     let mut headers = HeaderMap::new();
     headers.insert("Prefer", "return=representation".parse()?);
 
@@ -216,7 +216,7 @@ pub fn post<T: Serialize + ?Sized>(
 
     // Ok, No_Content are acceptable because some of our RPC code returns that.
     if ![StatusCode::CREATED, StatusCode::OK, StatusCode::NO_CONTENT].contains(&status) {
-        debug!("Response: {:?}", &response.text()?);
+        debug!("Response: {:?}", response.text()?);
         return Err(CommandError::WrongResponseStatus(status.as_u16()));
     }
     if status == StatusCode::NO_CONTENT {
@@ -227,13 +227,13 @@ pub fn post<T: Serialize + ?Sized>(
 }
 
 pub fn delete(authentication: &Authentication, endpoint: &str) -> anyhow::Result<(), CommandError> {
-    let url = format!("{}/{}", &authentication.config.url, endpoint);
+    let url = format!("{}/{}", authentication.config.url, endpoint);
     let response = authentication.build_client()?.delete(url).send()?;
 
     let status = response.status();
 
     if ![StatusCode::OK, StatusCode::NO_CONTENT].contains(&status) {
-        debug!("Response: {:?}", &response.text()?);
+        debug!("Response: {:?}", response.text()?);
         return Err(CommandError::WrongResponseStatus(status.as_u16()));
     }
     Ok(())
@@ -244,7 +244,7 @@ pub fn patch<T: Serialize + ?Sized>(
     endpoint: &str,
     payload: &T,
 ) -> anyhow::Result<serde_json::Value, CommandError> {
-    let url = format!("{}/{}", &authentication.config.url, endpoint);
+    let url = format!("{}/{}", authentication.config.url, endpoint);
     let mut headers = HeaderMap::new();
     headers.insert("Prefer", "return=representation".parse()?);
 
@@ -257,7 +257,7 @@ pub fn patch<T: Serialize + ?Sized>(
 
     let status = response.status();
     if status != StatusCode::OK {
-        debug!("Response: {:?}", &response.text()?);
+        debug!("Response: {:?}", response.text()?);
         return Err(CommandError::WrongResponseStatus(status.as_u16()));
     }
 

--- a/src/commands/screen.rs
+++ b/src/commands/screen.rs
@@ -36,7 +36,7 @@ impl ScreenCommand {
         pin: &str,
         maybe_name: Option<String>,
     ) -> anyhow::Result<Screens, CommandError> {
-        let url = format!("{}/v3/screens/", &self.authentication.config.url);
+        let url = format!("{}/v3/screens/", self.authentication.config.url);
         let mut payload = HashMap::new();
         payload.insert("pin".to_string(), pin.to_string());
         if let Some(name) = maybe_name {


### PR DESCRIPTION
CI supply-chain hardening, plus the dependency-update plumbing that prompted it.

## Background

Five Dependabot PRs (#280, #283, #288, #289, #290) sat open for up to three months. All five turned out to be already superseded by #297 (`7531baa`) and #299 (`5dad863`) — every target version was at or below what `Cargo.lock` already had. They've been closed. This PR addresses why they accumulated, and what turned up while looking.

## Changes

### 1. Add `.github/dependabot.yml`

The repo had no Dependabot config at all, so security updates ran with default settings and opened one PR per advisory.

- **Cargo — security updates grouped** into a single PR. Groups default to version updates, so `applies-to: security-updates` is required.
- **Cargo — version updates stay disabled** via `open-pull-requests-limit: 0`. This repo takes CVE-driven bumps only; enabling routine version updates would *add* PR volume rather than reduce it. Deliberate no-change to current behavior.
- **GitHub Actions — grouped**, both version and security. Not previously covered at all.

### 2. Drop unmaintained / third-party actions

- `actions-rs/clippy-check@v1.0.7` → `cargo clippy` directly. The actions-rs org has been archived since 2021 and the action runs on the deprecated Node 12 runtime.
- `dtolnay/rust-toolchain` → `rustup`, in `docs.yml`, `release.yml`, and `fmt.yml`. The runners have rustup preinstalled. **No `dtolnay` references remain.**

Permissions on the lint job drop to `contents: read` — `pull-requests: write` and `checks: write` existed only so the action could post check annotations.

### 3. Pin all third-party actions to commit SHAs

Nothing was digest-pinned. Four actions ran from **mutable branch refs** — `dtolnay/rust-toolchain@master`, `@nightly`, `sbomify/github-action@master`, `DeterminateSystems/flakehub-cache-action@main` — meaning any upstream push executed automatically. Two of those run in `release.yml` and `sbom.yml`, which build and attest release artifacts.

Every third-party reference is now pinned to a full SHA with the version as a trailing comment. Dependabot updates digest pins and maintains those comments, which is what the grouping in (1) is for.

`screenly/cli@master` is intentionally left unpinned: `actions.yml` exercises the CLI at master by design.

### 4. Upgrade outdated actions

- `actions/checkout` v3 → v4 in `docs.yml` and `release.yml`, matching the other workflows. v3 runs on deprecated Node 16.
- `softprops/action-gh-release` v1 → v3.0.2. Also a Node 16 action; v3 runs Node 24. Input-compatible — every input this workflow uses (`files`, plus the `GITHUB_TOKEN` env) still exists in v3, with only additions.
- `sbomify/github-action` `master` → `v26.7.0`. `action.yml` is byte-identical between the two, so the interface is unchanged. Note this moves *back* 10 commits — from an untagged branch tip onto the latest release, which is the point.
- `flakehub-cache-action` needed no change: its pinned SHA is already identical to `v3.21.7`, so only the trailing comment was corrected.

### 5. Fix 19 clippy warnings and enforce the gate

`useless_borrows_in_formatting` has fired since clippy 1.97 but went unnoticed, because the old actions-rs step only annotated warnings rather than failing on them. Removed 19 redundant `&` in `format!`/`debug!`/`println!` args across six files via `cargo clippy --fix` — 19 insertions, 19 deletions, inert since formatting traits auto-deref.

With the tree clean, the clippy step now runs `-D warnings` so these can't silently accumulate again.

### 6. Path-filter fix

`lint.yml` was added to its own `paths` filter. Previously, edits to the lint workflow didn't run it, so a broken lint config could merge unnoticed.

## Verification

All 9 checks pass. Locally, against clippy/rustc **1.97.1** (matching the 1.97 the runner ships):

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 200 passed, 0 failed
- `cargo fmt --all --check` — clean
- `cargo build --all-targets` — clean
- All workflow YAML parses

## Reviewer notes — please read before merging

**`release.yml` and `sbom.yml` trigger only on `v*` tags, so no PR check exercises them.** Green CI on this PR says nothing about either. This branch changes the release pipeline in three unverified ways:

1. `dtolnay/rust-toolchain` → `rustup` across the 8-target build matrix
2. `actions/checkout` v3 → v4
3. `action-gh-release` v1 → v3.0.2 (two major versions)

A throwaway pre-release tag is the only way to confirm these before a real release depends on them. **This is the main risk in the PR.**

**Pinning `sbomify/github-action` is largely cosmetic.** Its `action.yml` runs `docker://ghcr.io/sbomify/sbomify-action:latest` — a mutable Docker tag. Whatever ref is pinned here, the executed code is whatever `:latest` resolves to at run time. `sbom.yml` therefore still has an unpinned supply chain, and it can't be fixed from this side; mitigating it means forking or replacing the action. This is the one real gap remaining.

**`rustfmt.toml`'s unstable options are now inert.** `group_imports` and `imports_granularity` only applied under nightly; `fmt.yml` now uses stable. Ordinary formatting drift is still caught, but import ordering is no longer enforced. Either delete them as dead config or keep them for developers who run nightly by choice.

**`-D warnings` with a floating toolchain will break again** when a future clippy adds lints — that's exactly how the 19 warnings here surfaced. It's the tradeoff for the gate being meaningful; the alternative is pinning the clippy toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
