### PR TITLE
Skip List screens action check on fork pull requests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   test-github-action-workflow:
+    # Secrets are not available to pull_request runs from forks, so the
+    # SCREENLY_API_TOKEN would be empty and `screen list` would fail auth.
+    # Only run this integration check for same-repository pull requests.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     name: List screens
     steps:


### PR DESCRIPTION
## Summary

The `List screens` check in [.github/workflows/actions.yml](.github/workflows/actions.yml) fails on every pull request opened from a fork.

`pull_request` runs triggered from a forked repository do not receive repository secrets (a GitHub security measure to keep untrusted PR code from exfiltrating them). As a result `${{ secrets.SCREENLY_API_TOKEN }}` expands to empty, the action runs `API_TOKEN= screenly screen list` unauthenticated, and it exits 1 after a few seconds. The failure is unrelated to any PR's changes, and the job uses `screenly/cli@master` so it never even exercises the PR's own code.

## Change

Guard the job with an `if` condition so it only runs for same-repository pull requests, where the secret is available:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs will simply skip the job instead of showing a red failure. Same-repo PRs (including maintainer branches) run it exactly as before.

I avoided `pull_request_target`, which would expose the secret to fork PR code and is a known security risk.