### PR TITLE
fix: bump default cli_version in action.yml to v1.2.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   cli_version:
     description: "Screenly CLI version."
-    default: "v1.1.1"
+    default: "v1.2.1"
 
 outputs:
   cli_commands_response:


### PR DESCRIPTION
## Summary

- The composite action's `cli_version` input defaulted to `v1.1.1`, a release that predates https://github.com/Screenly/cli/pull/284, which removed the hard error guard that failed deploys with "No changes detected" when there was nothing to upload.
- Consumers of this action that do not override `cli_version` were silently exposed to that failure mode.
- The fix from PR #284 is included starting in `v1.2.0`. This bumps the default to `v1.2.1`, the latest release.