### PR TITLE
Publish Claude Artifact HTML as a Screenly Edge App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ result*
 
 # Local MCP Bundle builds (release artifacts)
 *.mcpb
+/mcpb-build/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,10 @@ warp = "0.3"
 # MCP server dependencies
 rmcp = { version = "1.4", default-features = false, features = ["macros", "server", "schemars", "transport-io"] }
 schemars = "1"
+tempfile = "3.8"
 
 [dev-dependencies]
 envtestkit = "1.1.2"
 httpmock = "0.8"
 swc_common = { version = "18", default-features = false, features = [] }
 swc_ecma_parser = { version = "32", default-features = false, features = ["typescript"] }
-tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The server communicates over stdio and exposes the full Screenly API as tools.
 | **Playlist Items** | `playlist_item_list`, `playlist_item_create`, `playlist_item_update`, `playlist_item_delete` |
 | **Labels** | `label_list`, `label_create`, `label_update`, `label_delete`, `label_link_screen`, `label_unlink_screen`, `label_link_playlist`, `label_unlink_playlist` |
 | **Shared Playlists** | `shared_playlist_list`, `shared_playlist_create`, `shared_playlist_delete` |
-| **Edge Apps** | `edge_app_list`, `edge_app_list_settings`, `edge_app_list_instances` |
+| **Edge Apps** | `edge_app_list`, `edge_app_list_settings`, `edge_app_list_instances`, `edge_app_publish_from_html` |
 
 Every tool is annotated with behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`), so MCP clients can tell read-only tools apart from ones that modify or delete data and prompt for confirmation before destructive actions.
 

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -49,7 +49,7 @@ Once installed, you can ask Claude to:
 - Organise content with asset groups and labels
 - Share a playlist with another team
 - Inspect Edge Apps, their settings, and their instances
-- Publish a Claude Artifact or HTML page as a Screenly app (Edge App), install an instance in Content, and push HTML updates as new revisions
+- Publish a Claude Artifact or HTML page as a Screenly app (Edge App), install an instance in Content, remember app/instance ids by name for later updates, and push HTML updates as new revisions
 
 ## Capabilities
 

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -49,7 +49,7 @@ Once installed, you can ask Claude to:
 - Organise content with asset groups and labels
 - Share a playlist with another team
 - Inspect Edge Apps, their settings, and their instances
-- Publish a Claude Artifact or HTML page as a Screenly app (Edge App), and push HTML updates as new revisions
+- Publish a Claude Artifact or HTML page as a Screenly app (Edge App), install an instance in Content, and push HTML updates as new revisions
 
 ## Capabilities
 

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -49,10 +49,11 @@ Once installed, you can ask Claude to:
 - Organise content with asset groups and labels
 - Share a playlist with another team
 - Inspect Edge Apps, their settings, and their instances
+- Publish a Claude Artifact or HTML page as an Edge App, and push HTML updates as new revisions
 
 ## Capabilities
 
-The bundle exposes 33 tools. Every tool is annotated so Claude knows whether it only reads
+The bundle exposes 34 tools. Every tool is annotated so Claude knows whether it only reads
 data or modifies your account, which means Claude will ask for confirmation before doing
 anything destructive.
 
@@ -65,10 +66,11 @@ anything destructive.
 | Playlist Items | `playlist_item_list`, `playlist_item_create`, `playlist_item_update`, `playlist_item_delete` |
 | Labels | `label_list`, `label_create`, `label_update`, `label_delete`, `label_link_screen`, `label_unlink_screen`, `label_link_playlist`, `label_unlink_playlist` |
 | Shared Playlists | `shared_playlist_list`, `shared_playlist_create`, `shared_playlist_delete` |
-| Edge Apps | `edge_app_list`, `edge_app_list_settings`, `edge_app_list_instances` |
+| Edge Apps | `edge_app_list`, `edge_app_list_settings`, `edge_app_list_instances`, `edge_app_publish_from_html` |
 
-Twelve of these tools are read-only. Thirteen are marked destructive (deletes, unlinks,
-and updates that overwrite existing fields) so clients can prompt before running them.
+Twelve of these tools are read-only. Fourteen are marked destructive (deletes, unlinks,
+updates that overwrite existing fields, and Edge App publishes) so clients can prompt
+before running them.
 
 ## Authentication
 

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -49,7 +49,7 @@ Once installed, you can ask Claude to:
 - Organise content with asset groups and labels
 - Share a playlist with another team
 - Inspect Edge Apps, their settings, and their instances
-- Publish a Claude Artifact or HTML page as an Edge App, and push HTML updates as new revisions
+- Publish a Claude Artifact or HTML page as a Screenly app (Edge App), and push HTML updates as new revisions
 
 ## Capabilities
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -188,6 +188,10 @@
     {
       "name": "edge_app_list_instances",
       "description": "List instances of an Edge App."
+    },
+    {
+      "name": "edge_app_publish_from_html",
+      "description": "Publish HTML as an Edge App. Wraps the page for digital signage (screenly.js + theme CSS variables). Omit app_id to create; pass app_id to deploy a new revision."
     }
   ],
   "compatibility": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -191,7 +191,7 @@
     },
     {
       "name": "edge_app_publish_from_html",
-      "description": "Publish HTML as an Edge App. Wraps the page for digital signage (screenly.js + theme CSS variables). Omit app_id to create; pass app_id to deploy a new revision."
+      "description": "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for digital signage (screenly.js + theme CSS variables). Omit app_id to create; pass app_id to deploy a new revision."
     }
   ],
   "compatibility": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -191,7 +191,7 @@
     },
     {
       "name": "edge_app_publish_from_html",
-      "description": "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tiles/pages), creates an instance so it appears in Content, and deploys. Omit app_id to create; pass app_id to update."
+      "description": "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tiles/pages), creates an instance so it appears in Content, and deploys. Remembers app_id/instance_id by name on this machine. Omit app_id to create or to update a remembered name; pass app_id to target a specific app."
     }
   ],
   "compatibility": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -191,7 +191,7 @@
     },
     {
       "name": "edge_app_publish_from_html",
-      "description": "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for digital signage (screenly.js + theme CSS variables). Omit app_id to create; pass app_id to deploy a new revision."
+      "description": "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tiles/pages), creates an instance so it appears in Content, and deploys. Omit app_id to create; pass app_id to update."
     }
   ],
   "compatibility": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -191,7 +191,7 @@
     },
     {
       "name": "edge_app_publish_from_html",
-      "description": "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tiles/pages), creates an instance so it appears in Content, and deploys. Remembers app_id/instance_id by name on this machine. Omit app_id to create or to update a remembered name; pass app_id to target a specific app."
+      "description": "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tab panels and carousel slides), creates an instance so it appears in Content, and deploys. Remembers app_id/instance_id by name on this machine. Omit app_id to create or to update a remembered name; pass app_id to target a specific app."
     }
   ],
   "compatibility": {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -189,7 +189,7 @@ pub struct EdgeAppPublishFromHtmlParam {
     #[schemars(description = "Name of the Edge App")]
     pub name: String,
     #[schemars(
-        description = "Full HTML source of the page or Claude Artifact. Fragments are wrapped into a complete document."
+        description = "Full HTML source of the page or Claude Artifact. Use this when uploading HTML as a Screenly app. Fragments are wrapped into a complete document."
     )]
     pub html: String,
     #[schemars(
@@ -871,9 +871,9 @@ impl ScreenlyMcpServer {
     }
 
     #[tool(
-        description = "Publish HTML as an Edge App. Wraps the page for digital signage (screenly.js + theme CSS variables). Omit app_id to create; pass app_id to deploy a new revision.",
+        description = "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for digital signage (screenly.js + theme CSS variables). Omit app_id to create; pass app_id to deploy a new revision.",
         annotations(
-            title = "Publish Edge App from HTML",
+            title = "Publish Screenly App from HTML",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = false,
@@ -918,9 +918,10 @@ impl rmcp::ServerHandler for ScreenlyMcpServer {
             '$TIME BETWEEN {32400000, 61200000}' (9AM-5PM), \
             '$TIME >= 32400000 AND $TIME <= 61200000 AND NOT $WEEKDAY IN {0, 6}' (business hours). \
             Time reference: 32400000=9AM, 43200000=12PM, 61200000=5PM, 72000000=8PM.\n\n\
-            EDGE APPS FROM HTML: To turn a Claude Artifact or webpage into a Screenly Edge App, \
-            call edge_app_publish_from_html with the full HTML source. Omit app_id to create. \
-            To update later, pass the same HTML (revised) plus the app_id from the first response \
+            SCREENLY APPS FROM HTML: If the user asks to upload HTML or a Claude Artifact as a \
+            Screenly app, app, or Edge App, call edge_app_publish_from_html with the full HTML \
+            source (not asset_create, which needs a public URL). Omit app_id to create. \
+            To update later, pass the revised HTML plus the app_id from the first response \
             so Screenly deploys a new revision.",
         )
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -871,7 +871,7 @@ impl ScreenlyMcpServer {
     }
 
     #[tool(
-        description = "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tiles/pages), creates an instance so it appears in Content, and deploys. Remembers app_id/instance_id by name on this machine. Omit app_id to create or to update a remembered name; pass app_id to target a specific app.",
+        description = "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tab panels and carousel slides), creates an instance so it appears in Content, and deploys. Remembers app_id/instance_id by name on this machine. Omit app_id to create or to update a remembered name; pass app_id to target a specific app.",
         annotations(
             title = "Publish Screenly App from HTML",
             read_only_hint = false,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -922,7 +922,7 @@ impl rmcp::ServerHandler for ScreenlyMcpServer {
             Screenly app, app, or Edge App, call edge_app_publish_from_html with the full HTML \
             source (not asset_create, which needs a public URL). This creates the app, deploys it, \
             and creates an instance so it appears in Content and can be scheduled on a screen. \
-            The tool saves app_id and instance_id locally by name (~/.screenly/mcp-edge-apps.json). \
+            The tool saves app_id and instance_id locally by name (~/.screenly.d/mcp-edge-apps.json). \
             To update later, call again with the same name and revised HTML; pass app_id when known, \
             otherwise the remembered name is enough. Keep the returned app_id and instance_id in mind \
             for the rest of the conversation.",

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -871,7 +871,7 @@ impl ScreenlyMcpServer {
     }
 
     #[tool(
-        description = "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for digital signage (screenly.js + theme CSS variables). Omit app_id to create; pass app_id to deploy a new revision.",
+        description = "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tiles/pages), creates an instance so it appears in Content, and deploys. Omit app_id to create; pass app_id to update.",
         annotations(
             title = "Publish Screenly App from HTML",
             read_only_hint = false,
@@ -920,9 +920,10 @@ impl rmcp::ServerHandler for ScreenlyMcpServer {
             Time reference: 32400000=9AM, 43200000=12PM, 61200000=5PM, 72000000=8PM.\n\n\
             SCREENLY APPS FROM HTML: If the user asks to upload HTML or a Claude Artifact as a \
             Screenly app, app, or Edge App, call edge_app_publish_from_html with the full HTML \
-            source (not asset_create, which needs a public URL). Omit app_id to create. \
-            To update later, pass the revised HTML plus the app_id from the first response \
-            so Screenly deploys a new revision.",
+            source (not asset_create, which needs a public URL). This creates the app, deploys it, \
+            and creates an instance so it appears in Content and can be scheduled on a screen. \
+            Omit app_id to create. To update later, pass the revised HTML plus the app_id from \
+            the first response so Screenly deploys a new revision; existing instances update automatically.",
         )
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -184,6 +184,22 @@ pub struct AppUuidParam {
     pub app_uuid: String,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct EdgeAppPublishFromHtmlParam {
+    #[schemars(description = "Name of the Edge App")]
+    pub name: String,
+    #[schemars(
+        description = "Full HTML source of the page or Claude Artifact. Fragments are wrapped into a complete document."
+    )]
+    pub html: String,
+    #[schemars(
+        description = "Existing Edge App UUID. Omit to create a new app. Pass this to publish an HTML update as a new revision (same as screenly edge-app deploy)."
+    )]
+    pub app_id: Option<String>,
+    #[schemars(description = "Optional description stored on the Edge App version")]
+    pub description: Option<String>,
+}
+
 // ============ SERVER STRUCT ============
 
 /// MCP Server for Screenly API
@@ -853,6 +869,37 @@ impl ScreenlyMcpServer {
             Err(e) => json!({"error": e}).to_string(),
         }
     }
+
+    #[tool(
+        description = "Publish HTML as an Edge App. Wraps the page for digital signage (screenly.js + theme CSS variables). Omit app_id to create; pass app_id to deploy a new revision.",
+        annotations(
+            title = "Publish Edge App from HTML",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
+    )]
+    fn edge_app_publish_from_html(
+        &self,
+        Parameters(EdgeAppPublishFromHtmlParam {
+            name,
+            html,
+            app_id,
+            description,
+        }): Parameters<EdgeAppPublishFromHtmlParam>,
+    ) -> String {
+        match EdgeAppTools::publish_from_html(
+            &self.auth,
+            &name,
+            &html,
+            app_id.as_deref(),
+            description.as_deref(),
+        ) {
+            Ok(result) => result,
+            Err(e) => json!({"error": e}).to_string(),
+        }
+    }
 }
 
 // ============ SERVER HANDLER ============
@@ -870,7 +917,11 @@ impl rmcp::ServerHandler for ScreenlyMcpServer {
             Examples: 'TRUE' (always show), '$WEEKDAY IN {1,2,3,4,5}' (weekdays only), \
             '$TIME BETWEEN {32400000, 61200000}' (9AM-5PM), \
             '$TIME >= 32400000 AND $TIME <= 61200000 AND NOT $WEEKDAY IN {0, 6}' (business hours). \
-            Time reference: 32400000=9AM, 43200000=12PM, 61200000=5PM, 72000000=8PM.",
+            Time reference: 32400000=9AM, 43200000=12PM, 61200000=5PM, 72000000=8PM.\n\n\
+            EDGE APPS FROM HTML: To turn a Claude Artifact or webpage into a Screenly Edge App, \
+            call edge_app_publish_from_html with the full HTML source. Omit app_id to create. \
+            To update later, pass the same HTML (revised) plus the app_id from the first response \
+            so Screenly deploys a new revision.",
         )
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -903,7 +903,7 @@ impl ScreenlyMcpServer {
         {
             Ok(Ok(result)) => result,
             Ok(Err(e)) => json!({"error": e}).to_string(),
-            Err(e) => json!({"error": format!("Publish task failed: {e}")}).to_string(),
+            Err(e) => json!({"error": format!("Publish task failed: {}", e)}).to_string(),
         }
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -880,7 +880,7 @@ impl ScreenlyMcpServer {
             open_world_hint = true
         )
     )]
-    fn edge_app_publish_from_html(
+    async fn edge_app_publish_from_html(
         &self,
         Parameters(EdgeAppPublishFromHtmlParam {
             name,
@@ -889,15 +889,21 @@ impl ScreenlyMcpServer {
             description,
         }): Parameters<EdgeAppPublishFromHtmlParam>,
     ) -> String {
-        match EdgeAppTools::publish_from_html(
-            &self.auth,
-            &name,
-            &html,
-            app_id.as_deref(),
-            description.as_deref(),
-        ) {
-            Ok(result) => result,
-            Err(e) => json!({"error": e}).to_string(),
+        let auth = Arc::clone(&self.auth);
+        match tokio::task::spawn_blocking(move || {
+            EdgeAppTools::publish_from_html(
+                &auth,
+                &name,
+                &html,
+                app_id.as_deref(),
+                description.as_deref(),
+            )
+        })
+        .await
+        {
+            Ok(Ok(result)) => result,
+            Ok(Err(e)) => json!({"error": e}).to_string(),
+            Err(e) => json!({"error": format!("Publish task failed: {e}")}).to_string(),
         }
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -193,7 +193,7 @@ pub struct EdgeAppPublishFromHtmlParam {
     )]
     pub html: String,
     #[schemars(
-        description = "Existing Edge App UUID. Omit to create a new app. Pass this to publish an HTML update as a new revision (same as screenly edge-app deploy)."
+        description = "Existing Edge App UUID. Prefer this when known. If omitted, the tool reuses the app_id saved locally for this exact name from a previous publish on this machine, or creates a new app."
     )]
     pub app_id: Option<String>,
     #[schemars(description = "Optional description stored on the Edge App version")]
@@ -871,7 +871,7 @@ impl ScreenlyMcpServer {
     }
 
     #[tool(
-        description = "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tiles/pages), creates an instance so it appears in Content, and deploys. Omit app_id to create; pass app_id to update.",
+        description = "Publish HTML as a Screenly app (Edge App). Use when the user says upload this as a Screenly app or Edge App. Wraps the page for unattended digital signage (no mouse/keyboard; auto-rotates tiles/pages), creates an instance so it appears in Content, and deploys. Remembers app_id/instance_id by name on this machine. Omit app_id to create or to update a remembered name; pass app_id to target a specific app.",
         annotations(
             title = "Publish Screenly App from HTML",
             read_only_hint = false,
@@ -922,8 +922,10 @@ impl rmcp::ServerHandler for ScreenlyMcpServer {
             Screenly app, app, or Edge App, call edge_app_publish_from_html with the full HTML \
             source (not asset_create, which needs a public URL). This creates the app, deploys it, \
             and creates an instance so it appears in Content and can be scheduled on a screen. \
-            Omit app_id to create. To update later, pass the revised HTML plus the app_id from \
-            the first response so Screenly deploys a new revision; existing instances update automatically.",
+            The tool saves app_id and instance_id locally by name (~/.screenly/mcp-edge-apps.json). \
+            To update later, call again with the same name and revised HTML; pass app_id when known, \
+            otherwise the remembered name is enough. Keep the returned app_id and instance_id in mind \
+            for the rest of the conversation.",
         )
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -695,7 +695,7 @@ fn test_mcpb_manifest_tools_match_server() {
     let server_src = fs::read_to_string(manifest_dir.join("src/mcp/server.rs"))
         .expect("src/mcp/server.rs should exist");
     let tool_re =
-        Regex::new(r#"(?s)#\[tool\(\s*description\s*=\s*"([^"]+)"[\s\S]*?\)\]\s*fn\s+(\w+)"#)
+        Regex::new(r#"(?s)#\[tool\(\s*description\s*=\s*"([^"]+)"[\s\S]*?\)\]\s*(?:async\s+)?fn\s+(\w+)"#)
             .unwrap();
 
     let mut server_tools = BTreeMap::new();

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -636,7 +636,25 @@ fn test_edge_app_list_instances() {
     assert!(result.is_ok());
 }
 
-/// Guard against the 33-tool catalog drifting between the MCPB manifest and
+#[test]
+fn test_edge_app_publish_from_html_rejects_empty_name() {
+    let mock_server = MockServer::start();
+    let auth = setup_auth(&mock_server);
+    let result = EdgeAppTools::publish_from_html(&auth, "  ", "<h1>Hi</h1>", None, None);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("name is required"));
+}
+
+#[test]
+fn test_edge_app_publish_from_html_rejects_empty_html() {
+    let mock_server = MockServer::start();
+    let auth = setup_auth(&mock_server);
+    let result = EdgeAppTools::publish_from_html(&auth, "Lobby Board", "   ", None, None);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("html is empty"));
+}
+
+/// Guard against the tool catalog drifting between the MCPB manifest and
 /// the `#[tool]` definitions in `server.rs` (names + descriptions).
 #[test]
 fn test_mcpb_manifest_tools_match_server() {
@@ -692,8 +710,8 @@ fn test_mcpb_manifest_tools_match_server() {
 
     assert_eq!(
         server_tools.len(),
-        33,
-        "expected 33 #[tool] handlers in server.rs, found {}",
+        34,
+        "expected 34 #[tool] handlers in server.rs, found {}",
         server_tools.len()
     );
     assert_eq!(

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -694,9 +694,10 @@ fn test_mcpb_manifest_tools_match_server() {
 
     let server_src = fs::read_to_string(manifest_dir.join("src/mcp/server.rs"))
         .expect("src/mcp/server.rs should exist");
-    let tool_re =
-        Regex::new(r#"(?s)#\[tool\(\s*description\s*=\s*"([^"]+)"[\s\S]*?\)\]\s*(?:async\s+)?fn\s+(\w+)"#)
-            .unwrap();
+    let tool_re = Regex::new(
+        r#"(?s)#\[tool\(\s*description\s*=\s*"([^"]+)"[\s\S]*?\)\]\s*(?:async\s+)?fn\s+(\w+)"#,
+    )
+    .unwrap();
 
     let mut server_tools = BTreeMap::new();
     for caps in tool_re.captures_iter(&server_src) {

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -1,9 +1,8 @@
 //! Edge App MCP tools.
 
 use std::collections::BTreeMap;
-use std::env;
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::{env, fs};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -86,7 +85,8 @@ const THEME_BOOTSTRAP_SCRIPT: &str = r#"<script data-screenly-mcp-theme="1">
       var orig = el.getAttribute("data-screenly-orig-display");
       if (on) {
         el.removeAttribute("hidden");
-        el.style.display = (orig && orig !== "none") ? orig : "block";
+        el.style.display = orig;
+        if (window.getComputedStyle(el).display === "none") el.style.display = "block";
       } else {
         el.setAttribute("hidden", "");
         el.style.display = "none";
@@ -223,7 +223,7 @@ impl EdgeAppTools {
         }
 
         let wrapped = wrap_html_for_edge_app(html)?;
-        let ready_signal = has_screenly_js_script(&wrapped);
+        let ready_signal = ready_signal_for_html(&wrapped);
         let dir = tempfile::tempdir()
             .map_err(|e| format!("Failed to create temporary Edge App directory: {}", e))?;
         let dir_path = dir.path();
@@ -616,18 +616,65 @@ pub(crate) fn wrap_html_for_edge_app(html: &str) -> Result<String, String> {
 }
 
 /// True when an opening `<script src=…>` tag points at `screenly.js`.
-/// A comment or code sample that merely mentions the filename does not count.
+/// Comments and inline script text that merely mention the filename do not count.
 fn has_screenly_js_script(html: &str) -> bool {
+    for_each_tag_outside_comments(html, |tag| {
+        opening_tag_name(tag) == "script" && tag.contains("src=") && tag.contains("screenly.js")
+    })
+}
+
+/// `<base href>` makes relative `screenly.js` resolve off-origin, so the player
+/// never gets `window.screenly` and must not wait on `ready_signal`.
+fn html_has_base_tag(html: &str) -> bool {
+    for_each_tag_outside_comments(html, |tag| opening_tag_name(tag) == "base")
+}
+
+fn ready_signal_for_html(html: &str) -> bool {
+    has_screenly_js_script(html) && !html_has_base_tag(html)
+}
+
+fn opening_tag_name(tag: &str) -> &str {
+    tag.trim_start()
+        .split(|c: char| c.is_ascii_whitespace() || c == '/')
+        .next()
+        .unwrap_or("")
+}
+
+/// Walks opening-tag interiors (`foo bar=baz` from `<foo bar=baz>`), skipping `<!-- -->`.
+fn for_each_tag_outside_comments(html: &str, mut on_tag: impl FnMut(&str) -> bool) -> bool {
     let lower = html.to_ascii_lowercase();
     let mut rest = lower.as_str();
-    while let Some(idx) = rest.find("<script") {
-        let after = &rest[idx + 7..];
+    while !rest.is_empty() {
+        if let Some(comment_at) = rest.find("<!--") {
+            let before = &rest[..comment_at];
+            if scan_tags(before, &mut on_tag) {
+                return true;
+            }
+            rest = &rest[comment_at + 4..];
+            match rest.find("-->") {
+                Some(end) => rest = &rest[end + 3..],
+                None => break,
+            }
+            continue;
+        }
+        return scan_tags(rest, &mut on_tag);
+    }
+    false
+}
+
+fn scan_tags(html: &str, on_tag: &mut impl FnMut(&str) -> bool) -> bool {
+    let mut rest = html;
+    while let Some(idx) = rest.find('<') {
+        let after = &rest[idx + 1..];
+        if after.starts_with('!') || after.starts_with('/') {
+            rest = after;
+            continue;
+        }
         let tag_end = after.find('>').unwrap_or(after.len());
-        let tag = &after[..tag_end];
-        if tag.contains("src=") && tag.contains("screenly.js") {
+        if on_tag(&after[..tag_end]) {
             return true;
         }
-        rest = after;
+        rest = &after[tag_end.min(after.len())..];
     }
     false
 }
@@ -675,6 +722,7 @@ mod wrap_tests {
         assert!(wrapped.contains("DWELL_MS"));
         assert!(wrapped.contains("signalReadyForRendering"));
         assert!(wrapped.contains("data-screenly-orig-display"));
+        assert!(wrapped.contains("getComputedStyle(el).display === \"none\""));
         assert!(!wrapped.contains(".tile"));
         assert!(!wrapped.contains("querySelectorAll(\"dialog\")"));
         assert!(!wrapped.contains("querySelectorAll(\"body *\")"));
@@ -745,16 +793,50 @@ mod wrap_tests {
         let html = r#"<script>console.log("screenly.js")</script>"#;
         assert!(!has_screenly_js_script(html));
     }
+
+    #[test]
+    fn wrap_injects_when_screenly_js_script_is_only_inside_a_comment() {
+        let html = r#"<!DOCTYPE html>
+<html>
+<head>
+<!-- <script src="screenly.js"></script> -->
+<title>Board</title>
+</head>
+<body><p>News</p></body>
+</html>"#;
+        assert!(!has_screenly_js_script(html));
+        let wrapped = wrap_html_for_edge_app(html).unwrap();
+        assert_eq!(wrapped.matches(SCREENLY_JS_SRC).count(), 1);
+        assert!(has_screenly_js_script(&wrapped));
+        assert!(ready_signal_for_html(&wrapped));
+    }
+
+    #[test]
+    fn ready_signal_is_off_when_document_has_a_base_tag() {
+        let html = r#"<!DOCTYPE html>
+<html>
+<head>
+<base href="https://example.com/">
+<title>Board</title>
+</head>
+<body><p>News</p></body>
+</html>"#;
+        let wrapped = wrap_html_for_edge_app(html).unwrap();
+        assert!(has_screenly_js_script(&wrapped));
+        assert!(html_has_base_tag(&wrapped));
+        assert!(!ready_signal_for_html(&wrapped));
+    }
 }
 
 #[cfg(test)]
 mod registry_tests {
-    use super::*;
-    use crate::authentication::Config;
     use httpmock::Method::GET;
     use httpmock::MockServer;
     use serde_json::json;
     use tempfile::tempdir;
+
+    use super::*;
+    use crate::authentication::Config;
 
     fn test_auth(url: &str, token: &str) -> Authentication {
         Authentication::new_with_config(Config::new(url.to_string()), token)

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -12,7 +12,7 @@ use crate::commands::edge_app::manifest::{
 use crate::commands::edge_app::EdgeAppCommand;
 
 /// Marker attribute so wrap is idempotent when HTML is published again.
-pub(crate) const THEME_BOOTSTRAP_MARKER: &str = "data-screenly-mcp-theme";
+const THEME_BOOTSTRAP_MARKER: &str = "data-screenly-mcp-theme";
 
 const SCREENLY_JS_SRC: &str = "screenly.js?version=1";
 
@@ -97,11 +97,11 @@ impl EdgeAppTools {
 
         let wrapped = wrap_html_for_edge_app(html)?;
         let dir = tempfile::tempdir()
-            .map_err(|e| format!("Failed to create temporary Edge App directory: {e}"))?;
+            .map_err(|e| format!("Failed to create temporary Edge App directory: {}", e))?;
         let dir_path = dir.path();
 
         fs::write(dir_path.join("index.html"), &wrapped)
-            .map_err(|e| format!("Failed to write index.html: {e}"))?;
+            .map_err(|e| format!("Failed to write index.html: {}", e))?;
 
         let existing_id = app_id
             .map(str::trim)
@@ -111,7 +111,7 @@ impl EdgeAppTools {
         let created = existing_id.is_none();
         let manifest = EdgeAppManifest {
             syntax: MANIFEST_VERSION.to_owned(),
-            id: existing_id.clone(),
+            id: existing_id,
             description: description
                 .map(str::trim)
                 .filter(|d| !d.is_empty())
@@ -126,17 +126,17 @@ impl EdgeAppTools {
 
         let manifest_path = dir_path.join("screenly.yml");
         EdgeAppManifest::save_to_file(&manifest, &manifest_path)
-            .map_err(|e| format!("Failed to write screenly.yml: {e}"))?;
+            .map_err(|e| format!("Failed to write screenly.yml: {}", e))?;
 
         let command = edge_app_command(auth);
         if created {
             command
                 .create_in_place(name, &manifest_path)
-                .map_err(|e| format!("Failed to create Edge App: {e}"))?;
+                .map_err(|e| format!("Failed to create Edge App: {}", e))?;
         }
 
         let app_id = EdgeAppManifest::new(&manifest_path)
-            .map_err(|e| format!("Failed to read Edge App id: {e}"))?
+            .map_err(|e| format!("Failed to read Edge App id: {}", e))?
             .id
             .ok_or_else(|| "Edge App id missing after create".to_string())?;
 
@@ -147,7 +147,7 @@ impl EdgeAppTools {
 
         let revision = command
             .deploy(Some(path), Some(false))
-            .map_err(|e| format!("Failed to deploy Edge App: {e}"))?;
+            .map_err(|e| format!("Failed to deploy Edge App: {}", e))?;
 
         serde_json::to_string_pretty(&json!({
             "app_id": app_id,
@@ -156,7 +156,7 @@ impl EdgeAppTools {
             "created": created,
             "message": "Reuse app_id with this tool to publish an HTML update as a new Edge App revision.",
         }))
-        .map_err(|e| format!("Failed to serialize response: {e}"))
+        .map_err(|e| format!("Failed to serialize response: {}", e))
     }
 }
 
@@ -182,7 +182,18 @@ pub(crate) fn wrap_html_for_edge_app(html: &str) -> Result<String, String> {
 
     if !has_html_shell {
         return Ok(format!(
-            "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n{screenly_script}\n</head>\n<body>\n{html}\n{THEME_BOOTSTRAP_SCRIPT}\n</body>\n</html>\n"
+            "<!DOCTYPE html>\n\
+             <html lang=\"en\">\n\
+             <head>\n\
+             <meta charset=\"utf-8\">\n\
+             <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n\
+             {screenly_script}\n\
+             </head>\n\
+             <body>\n\
+             {html}\n\
+             {THEME_BOOTSTRAP_SCRIPT}\n\
+             </body>\n\
+             </html>\n"
         ));
     }
 

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -1,8 +1,11 @@
 //! Edge App MCP tools.
 
+use std::collections::BTreeMap;
+use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::authentication::Authentication;
@@ -11,6 +14,23 @@ use crate::commands::edge_app::manifest::{
     EdgeAppManifest, Entrypoint, EntrypointType, MANIFEST_VERSION,
 };
 use crate::commands::edge_app::EdgeAppCommand;
+
+/// Override path for the local name → app/instance cache (used in tests).
+const MCP_EDGE_APPS_PATH_ENV: &str = "SCREENLY_MCP_EDGE_APPS_PATH";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct McpEdgeAppRecord {
+    app_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    instance_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct McpEdgeAppRegistry {
+    /// Exact display name → last published Edge App / instance.
+    #[serde(default)]
+    apps: BTreeMap<String, McpEdgeAppRecord>,
+}
 
 /// Marker attribute so wrap is idempotent when HTML is published again.
 const THEME_BOOTSTRAP_MARKER: &str = "data-screenly-mcp-theme";
@@ -194,8 +214,9 @@ impl EdgeAppTools {
 
     /// Create or update an Edge App from HTML (Claude Artifact / webpage).
     ///
-    /// Omitting `app_id` creates a new app. Passing `app_id` deploys a new revision,
-    /// the same as `screenly edge-app deploy`.
+    /// Omitting `app_id` creates a new app unless the same `name` was published
+    /// before on this machine (`~/.screenly/mcp-edge-apps.json`). Passing
+    /// `app_id` always deploys a new revision for that app.
     pub fn publish_from_html(
         auth: &Authentication,
         name: &str,
@@ -216,10 +237,17 @@ impl EdgeAppTools {
         fs::write(dir_path.join("index.html"), &wrapped)
             .map_err(|e| format!("Failed to write index.html: {}", e))?;
 
-        let existing_id = app_id
+        let explicit_id = app_id
             .map(str::trim)
             .filter(|id| !id.is_empty())
             .map(ToOwned::to_owned);
+        let remembered = if explicit_id.is_none() {
+            lookup_remembered_app(name)
+        } else {
+            None
+        };
+        let from_memory = remembered.is_some();
+        let existing_id = explicit_id.or_else(|| remembered.map(|r| r.app_id));
 
         let created = existing_id.is_none();
         let manifest = EdgeAppManifest {
@@ -265,6 +293,8 @@ impl EdgeAppTools {
         let (instance_id, instance_created) =
             ensure_instance(auth, &app_id, name, &dir_path.join("instance.yml"))?;
 
+        remember_published_app(name, &app_id, instance_id.as_deref())?;
+
         serde_json::to_string_pretty(&json!({
             "app_id": app_id,
             "instance_id": instance_id,
@@ -272,10 +302,71 @@ impl EdgeAppTools {
             "name": name,
             "revision": revision,
             "created": created,
-            "message": "The instance appears in Screenly Content and can be scheduled on a screen. Reuse app_id to publish an HTML update as a new revision.",
+            "resolved_from_memory": from_memory,
+            "message": "IDs are saved locally under ~/.screenly/mcp-edge-apps.json for this name. Later, call this tool again with the same name (and updated HTML) to deploy a new revision; app_id is optional when the name is remembered.",
         }))
         .map_err(|e| format!("Failed to serialize response: {}", e))
     }
+}
+
+fn registry_path() -> Result<PathBuf, String> {
+    if let Ok(path) = env::var(MCP_EDGE_APPS_PATH_ENV) {
+        let path = path.trim();
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| "Home directory not found".to_string())?;
+    Ok(home.join(".screenly").join("mcp-edge-apps.json"))
+}
+
+fn load_registry() -> Result<McpEdgeAppRegistry, String> {
+    let path = registry_path()?;
+    if !path.exists() {
+        return Ok(McpEdgeAppRegistry::default());
+    }
+
+    let data = fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    if data.trim().is_empty() {
+        return Ok(McpEdgeAppRegistry::default());
+    }
+
+    serde_json::from_str(&data).map_err(|e| format!("Failed to parse {}: {}", path.display(), e))
+}
+
+fn save_registry(registry: &McpEdgeAppRegistry) -> Result<(), String> {
+    let path = registry_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create {}: {}", parent.display(), e))?;
+    }
+
+    let data = serde_json::to_string_pretty(registry)
+        .map_err(|e| format!("Failed to serialize Edge App memory: {}", e))?;
+    fs::write(&path, format!("{data}\n"))
+        .map_err(|e| format!("Failed to write {}: {}", path.display(), e))
+}
+
+fn lookup_remembered_app(name: &str) -> Option<McpEdgeAppRecord> {
+    load_registry().ok()?.apps.get(name).cloned()
+}
+
+fn remember_published_app(
+    name: &str,
+    app_id: &str,
+    instance_id: Option<&str>,
+) -> Result<(), String> {
+    let mut registry = load_registry()?;
+    registry.apps.insert(
+        name.to_string(),
+        McpEdgeAppRecord {
+            app_id: app_id.to_string(),
+            instance_id: instance_id.map(ToOwned::to_owned),
+        },
+    );
+    save_registry(&registry)
 }
 
 fn ensure_instance(
@@ -447,5 +538,31 @@ mod wrap_tests {
     #[test]
     fn wrap_rejects_empty_html() {
         assert!(wrap_html_for_edge_app("   ").is_err());
+    }
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn remember_and_lookup_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mcp-edge-apps.json");
+        let path_str = path.to_str().unwrap();
+
+        temp_env::with_var(MCP_EDGE_APPS_PATH_ENV, Some(path_str), || {
+            assert!(lookup_remembered_app("Lobby Board").is_none());
+            remember_published_app("Lobby Board", "app-1", Some("inst-1")).unwrap();
+
+            let remembered = lookup_remembered_app("Lobby Board").unwrap();
+            assert_eq!(remembered.app_id, "app-1");
+            assert_eq!(remembered.instance_id.as_deref(), Some("inst-1"));
+
+            remember_published_app("Lobby Board", "app-1", Some("inst-2")).unwrap();
+            let updated = lookup_remembered_app("Lobby Board").unwrap();
+            assert_eq!(updated.instance_id.as_deref(), Some("inst-2"));
+        });
     }
 }

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -13,6 +13,9 @@ use crate::commands;
 use crate::commands::edge_app::manifest::{
     EdgeAppManifest, Entrypoint, EntrypointType, MANIFEST_VERSION,
 };
+use crate::commands::edge_app::utils::{
+    transform_edge_app_path_to_manifest, transform_instance_path_to_instance_manifest,
+};
 use crate::commands::edge_app::EdgeAppCommand;
 
 /// Override path for the local name → app/instance cache (used in tests).
@@ -224,6 +227,7 @@ impl EdgeAppTools {
         let dir = tempfile::tempdir()
             .map_err(|e| format!("Failed to create temporary Edge App directory: {}", e))?;
         let dir_path = dir.path();
+        let (manifest_path, instance_manifest_path, path) = publish_dir_paths(dir_path)?;
 
         fs::write(dir_path.join("index.html"), &wrapped)
             .map_err(|e| format!("Failed to write index.html: {}", e))?;
@@ -232,13 +236,18 @@ impl EdgeAppTools {
             .map(str::trim)
             .filter(|id| !id.is_empty())
             .map(ToOwned::to_owned);
-        let remembered = if explicit_id.is_none() {
-            lookup_remembered_app(auth, name)
-        } else {
-            None
-        };
-        let from_memory = remembered.is_some();
-        let existing_id = explicit_id.or_else(|| remembered.map(|r| r.app_id));
+        let remembered = lookup_remembered_app(auth, name);
+        let from_memory = explicit_id.is_none() && remembered.is_some();
+        let existing_id = explicit_id
+            .clone()
+            .or_else(|| remembered.as_ref().map(|r| r.app_id.clone()));
+        let preferred_instance_id = remembered.as_ref().and_then(|r| {
+            if existing_id.as_deref() == Some(r.app_id.as_str()) {
+                r.instance_id.clone()
+            } else {
+                None
+            }
+        });
 
         let created = existing_id.is_none();
         let manifest = EdgeAppManifest {
@@ -257,9 +266,8 @@ impl EdgeAppTools {
             ..Default::default()
         };
 
-        let manifest_path = dir_path.join("screenly.yml");
         EdgeAppManifest::save_to_file(&manifest, &manifest_path)
-            .map_err(|e| format!("Failed to write screenly.yml: {}", e))?;
+            .map_err(|e| format!("Failed to write {}: {}", manifest_path.display(), e))?;
 
         let command = edge_app_command(auth);
         if created {
@@ -273,25 +281,25 @@ impl EdgeAppTools {
             .id
             .ok_or_else(|| "Edge App id missing after create".to_string())?;
 
-        let path = dir_path
-            .to_str()
-            .ok_or_else(|| "Edge App path is not valid UTF-8".to_string())?
-            .to_string();
-
         let revision = command
             .deploy(Some(path), Some(false))
             .map_err(|e| format!("Failed to deploy Edge App: {}", e))?;
 
         // Create/deploy already happened. Instance + local memory must not hide app_id.
         let mut warnings: Vec<String> = Vec::new();
-        let (instance_id, instance_created) =
-            match ensure_instance(auth, &app_id, name, &dir_path.join("instance.yml")) {
-                Ok(pair) => pair,
-                Err(e) => {
-                    warnings.push(e);
-                    (None, false)
-                }
-            };
+        let (instance_id, instance_created) = match ensure_instance(
+            auth,
+            &app_id,
+            name,
+            preferred_instance_id.as_deref(),
+            &instance_manifest_path,
+        ) {
+            Ok(pair) => pair,
+            Err(e) => {
+                warnings.push(e);
+                (None, false)
+            }
+        };
 
         let saved_to_memory =
             match remember_published_app(auth, name, &app_id, instance_id.as_deref()) {
@@ -342,6 +350,18 @@ fn publish_follow_up_message(saved_to_memory: bool) -> &'static str {
 fn serialize_publish_success(response: PublishFromHtmlResponse) -> Result<String, String> {
     serde_json::to_string_pretty(&response)
         .map_err(|e| format!("Failed to serialize response: {}", e))
+}
+
+fn publish_dir_paths(dir_path: &Path) -> Result<(PathBuf, PathBuf, String), String> {
+    let path = dir_path
+        .to_str()
+        .ok_or_else(|| "Edge App path is not valid UTF-8".to_string())?
+        .to_string();
+    let manifest_path = transform_edge_app_path_to_manifest(&Some(path.clone()))
+        .map_err(|e| format!("Failed to resolve Edge App manifest path: {e}"))?;
+    let instance_path = transform_instance_path_to_instance_manifest(&Some(path.clone()))
+        .map_err(|e| format!("Failed to resolve Edge App instance path: {e}"))?;
+    Ok((manifest_path, instance_path, path))
 }
 
 fn registry_path() -> Result<PathBuf, String> {
@@ -468,6 +488,7 @@ fn ensure_instance(
     auth: &Authentication,
     app_id: &str,
     name: &str,
+    preferred_instance_id: Option<&str>,
     instance_manifest_path: &Path,
 ) -> Result<(Option<String>, bool), String> {
     let command = edge_app_command(auth);
@@ -475,11 +496,8 @@ fn ensure_instance(
         .list_instances(app_id)
         .map_err(|e| format!("Failed to list Edge App instances: {}", e))?;
 
-    if let Some(id) = listed.value.as_array().and_then(|rows| {
-        rows.iter()
-            .find_map(|row| row.get("id").and_then(|v| v.as_str()))
-            .map(ToOwned::to_owned)
-    }) {
+    let rows = listed.value.as_array().cloned().unwrap_or_default();
+    if let Some(id) = pick_existing_instance(&rows, preferred_instance_id, name) {
         return Ok((Some(id), false));
     }
 
@@ -487,6 +505,40 @@ fn ensure_instance(
         .create_instance(instance_manifest_path, app_id, name)
         .map_err(|e| format!("Failed to create Edge App instance: {}", e))?;
     Ok((Some(instance_id), true))
+}
+
+fn pick_existing_instance(
+    rows: &[serde_json::Value],
+    preferred_instance_id: Option<&str>,
+    name: &str,
+) -> Option<String> {
+    if let Some(preferred) = preferred_instance_id.filter(|id| !id.is_empty()) {
+        if rows
+            .iter()
+            .any(|row| row.get("id").and_then(|v| v.as_str()) == Some(preferred))
+        {
+            return Some(preferred.to_string());
+        }
+    }
+
+    if let Some(id) = rows.iter().find_map(|row| {
+        if row.get("name").and_then(|v| v.as_str()) == Some(name) {
+            row.get("id").and_then(|v| v.as_str()).map(ToOwned::to_owned)
+        } else {
+            None
+        }
+    }) {
+        return Some(id);
+    }
+
+    if rows.len() == 1 {
+        return rows[0]
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned);
+    }
+
+    None
 }
 
 fn edge_app_command(auth: &Authentication) -> EdgeAppCommand {
@@ -804,5 +856,45 @@ mod registry_tests {
             .as_str()
             .unwrap()
             .contains("Keep this app_id"));
+    }
+
+    #[test]
+    fn pick_existing_instance_prefers_remembered_id_then_name() {
+        let rows = vec![
+            json!({"id": "inst-a", "name": "Other"}),
+            json!({"id": "inst-b", "name": "Lobby Board"}),
+        ];
+        assert_eq!(
+            pick_existing_instance(&rows, Some("inst-a"), "Lobby Board").as_deref(),
+            Some("inst-a")
+        );
+        assert_eq!(
+            pick_existing_instance(&rows, Some("gone"), "Lobby Board").as_deref(),
+            Some("inst-b")
+        );
+        assert_eq!(
+            pick_existing_instance(&rows, None, "Missing").as_deref(),
+            None
+        );
+        assert_eq!(
+            pick_existing_instance(&[json!({"id": "only", "name": "X"})], None, "Y").as_deref(),
+            Some("only")
+        );
+    }
+
+    #[test]
+    fn publish_dir_paths_honours_manifest_and_instance_env() {
+        let dir = tempdir().unwrap();
+        temp_env::with_vars(
+            [
+                ("MANIFEST_FILE_NAME", Some("custom.yml")),
+                ("INSTANCE_FILE_NAME", Some("inst.yml")),
+            ],
+            || {
+                let (manifest, instance, _) = publish_dir_paths(dir.path()).unwrap();
+                assert_eq!(manifest.file_name().and_then(|n| n.to_str()), Some("custom.yml"));
+                assert_eq!(instance.file_name().and_then(|n| n.to_str()), Some("inst.yml"));
+            },
+        );
     }
 }

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -305,7 +305,7 @@ impl EdgeAppTools {
             match remember_published_app(auth, name, &app_id, instance_id.as_deref()) {
                 Ok(()) => true,
                 Err(e) => {
-                    warnings.push(format!("Failed to save app_id locally: {e}"));
+                    warnings.push(format!("Failed to save app_id locally: {}", e));
                     false
                 }
             };
@@ -358,9 +358,9 @@ fn publish_dir_paths(dir_path: &Path) -> Result<(PathBuf, PathBuf, String), Stri
         .ok_or_else(|| "Edge App path is not valid UTF-8".to_string())?
         .to_string();
     let manifest_path = transform_edge_app_path_to_manifest(&Some(path.clone()))
-        .map_err(|e| format!("Failed to resolve Edge App manifest path: {e}"))?;
+        .map_err(|e| format!("Failed to resolve Edge App manifest path: {}", e))?;
     let instance_path = transform_instance_path_to_instance_manifest(&Some(path.clone()))
-        .map_err(|e| format!("Failed to resolve Edge App instance path: {e}"))?;
+        .map_err(|e| format!("Failed to resolve Edge App instance path: {}", e))?;
     Ok((manifest_path, instance_path, path))
 }
 
@@ -477,7 +477,7 @@ fn forget_published_app(auth: &Authentication, name: &str) -> Result<(), String>
 fn app_exists_in_account(auth: &Authentication, app_id: &str) -> Result<bool, String> {
     let endpoint = format!("v4/edge-apps?select=id&id=eq.{app_id}&deleted=eq.false");
     let result = commands::get(auth, &endpoint)
-        .map_err(|e| format!("Failed to look up Edge App {app_id}: {e}"))?;
+        .map_err(|e| format!("Failed to look up Edge App {}: {}", app_id, e))?;
     Ok(result
         .as_array()
         .map(|rows| !rows.is_empty())
@@ -523,7 +523,9 @@ fn pick_existing_instance(
 
     if let Some(id) = rows.iter().find_map(|row| {
         if row.get("name").and_then(|v| v.as_str()) == Some(name) {
-            row.get("id").and_then(|v| v.as_str()).map(ToOwned::to_owned)
+            row.get("id")
+                .and_then(|v| v.as_str())
+                .map(ToOwned::to_owned)
         } else {
             None
         }
@@ -892,8 +894,14 @@ mod registry_tests {
             ],
             || {
                 let (manifest, instance, _) = publish_dir_paths(dir.path()).unwrap();
-                assert_eq!(manifest.file_name().and_then(|n| n.to_str()), Some("custom.yml"));
-                assert_eq!(instance.file_name().and_then(|n| n.to_str()), Some("inst.yml"));
+                assert_eq!(
+                    manifest.file_name().and_then(|n| n.to_str()),
+                    Some("custom.yml")
+                );
+                assert_eq!(
+                    instance.file_name().and_then(|n| n.to_str()),
+                    Some("inst.yml")
+                );
             },
         );
     }

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -6,7 +6,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
 use crate::authentication::Authentication;
 use crate::commands;
@@ -17,6 +16,11 @@ use crate::commands::edge_app::EdgeAppCommand;
 
 /// Override path for the local name → app/instance cache (used in tests).
 const MCP_EDGE_APPS_PATH_ENV: &str = "SCREENLY_MCP_EDGE_APPS_PATH";
+
+/// Directory next to the `~/.screenly` *token file* — that path is a regular
+/// file (`authentication.rs`), so we cannot store JSON under `~/.screenly/`.
+const MCP_EDGE_APPS_DIR_NAME: &str = ".screenly.d";
+const MCP_EDGE_APPS_FILE_NAME: &str = "mcp-edge-apps.json";
 
 /// Default Edge App icon for Claude Artifact publishes (screenly.yml `icon`).
 const DEFAULT_CLAUDE_APP_ICON: &str =
@@ -219,7 +223,7 @@ impl EdgeAppTools {
     /// Create or update an Edge App from HTML (Claude Artifact / webpage).
     ///
     /// Omitting `app_id` creates a new app unless the same `name` was published
-    /// before on this machine (`~/.screenly/mcp-edge-apps.json`). Passing
+    /// before on this machine (`~/.screenly.d/mcp-edge-apps.json`). Passing
     /// `app_id` always deploys a new revision for that app.
     pub fn publish_from_html(
         auth: &Authentication,
@@ -295,23 +299,65 @@ impl EdgeAppTools {
             .deploy(Some(path), Some(false))
             .map_err(|e| format!("Failed to deploy Edge App: {}", e))?;
 
+        // Create/deploy already happened. Instance + local memory must not hide app_id.
+        let mut warnings: Vec<String> = Vec::new();
         let (instance_id, instance_created) =
-            ensure_instance(auth, &app_id, name, &dir_path.join("instance.yml"))?;
+            match ensure_instance(auth, &app_id, name, &dir_path.join("instance.yml")) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    warnings.push(e);
+                    (None, false)
+                }
+            };
 
-        remember_published_app(name, &app_id, instance_id.as_deref())?;
+        let saved_to_memory = match remember_published_app(name, &app_id, instance_id.as_deref()) {
+            Ok(()) => true,
+            Err(e) => {
+                warnings.push(format!("Failed to save app_id locally: {e}"));
+                false
+            }
+        };
 
-        serde_json::to_string_pretty(&json!({
-            "app_id": app_id,
-            "instance_id": instance_id,
-            "instance_created": instance_created,
-            "name": name,
-            "revision": revision,
-            "created": created,
-            "resolved_from_memory": from_memory,
-            "message": "IDs are saved locally under ~/.screenly/mcp-edge-apps.json for this name. Later, call this tool again with the same name (and updated HTML) to deploy a new revision; app_id is optional when the name is remembered.",
-        }))
-        .map_err(|e| format!("Failed to serialize response: {}", e))
+        serialize_publish_success(PublishFromHtmlResponse {
+            app_id,
+            instance_id,
+            instance_created,
+            name: name.to_string(),
+            revision,
+            created,
+            resolved_from_memory: from_memory,
+            saved_to_memory,
+            warnings,
+            message: publish_follow_up_message(saved_to_memory).to_string(),
+        })
     }
+}
+
+#[derive(Serialize)]
+struct PublishFromHtmlResponse {
+    app_id: String,
+    instance_id: Option<String>,
+    instance_created: bool,
+    name: String,
+    revision: u32,
+    created: bool,
+    resolved_from_memory: bool,
+    saved_to_memory: bool,
+    warnings: Vec<String>,
+    message: String,
+}
+
+fn publish_follow_up_message(saved_to_memory: bool) -> &'static str {
+    if saved_to_memory {
+        "IDs are saved locally under ~/.screenly.d/mcp-edge-apps.json for this name. Later, call this tool again with the same name (and updated HTML) to deploy a new revision; app_id is optional when the name is remembered."
+    } else {
+        "Keep this app_id. Local memory could not be updated; pass app_id on the next publish to update the same app."
+    }
+}
+
+fn serialize_publish_success(response: PublishFromHtmlResponse) -> Result<String, String> {
+    serde_json::to_string_pretty(&response)
+        .map_err(|e| format!("Failed to serialize response: {}", e))
 }
 
 fn registry_path() -> Result<PathBuf, String> {
@@ -323,7 +369,9 @@ fn registry_path() -> Result<PathBuf, String> {
     }
 
     let home = dirs::home_dir().ok_or_else(|| "Home directory not found".to_string())?;
-    Ok(home.join(".screenly").join("mcp-edge-apps.json"))
+    Ok(home
+        .join(MCP_EDGE_APPS_DIR_NAME)
+        .join(MCP_EDGE_APPS_FILE_NAME))
 }
 
 fn load_registry() -> Result<McpEdgeAppRegistry, String> {
@@ -569,5 +617,47 @@ mod registry_tests {
             let updated = lookup_remembered_app("Lobby Board").unwrap();
             assert_eq!(updated.instance_id.as_deref(), Some("inst-2"));
         });
+    }
+
+    #[test]
+    fn default_registry_path_is_not_the_token_file() {
+        temp_env::with_var_unset(MCP_EDGE_APPS_PATH_ENV, || {
+            let path = registry_path().unwrap();
+            assert_eq!(
+                path.file_name().and_then(|n| n.to_str()),
+                Some(MCP_EDGE_APPS_FILE_NAME)
+            );
+            assert_eq!(
+                path.parent()
+                    .and_then(|p| p.file_name())
+                    .and_then(|n| n.to_str()),
+                Some(MCP_EDGE_APPS_DIR_NAME)
+            );
+        });
+    }
+
+    #[test]
+    fn success_json_keeps_app_id_when_bookkeeping_fails() {
+        let raw = serialize_publish_success(PublishFromHtmlResponse {
+            app_id: "app-1".to_string(),
+            instance_id: None,
+            instance_created: false,
+            name: "Lobby Board".to_string(),
+            revision: 3,
+            created: true,
+            resolved_from_memory: false,
+            saved_to_memory: false,
+            warnings: vec!["Failed to save app_id locally: File exists".to_string()],
+            message: publish_follow_up_message(false).to_string(),
+        })
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(value["app_id"], "app-1");
+        assert_eq!(value["saved_to_memory"], false);
+        assert_eq!(value["warnings"].as_array().unwrap().len(), 1);
+        assert!(value["message"]
+            .as_str()
+            .unwrap()
+            .contains("Keep this app_id"));
     }
 }

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -143,7 +143,10 @@ const THEME_BOOTSTRAP_SCRIPT: &str = r#"<script data-screenly-mcp-theme="1">
 
   onReady(function () {
     try { startSignage(); } catch (e) {}
-    if (window.screenly && typeof screenly.signalReady === "function") {
+    if (!window.screenly) return;
+    if (typeof screenly.signalReadyForRendering === "function") {
+      try { screenly.signalReadyForRendering(); } catch (e) {}
+    } else if (typeof screenly.signalReady === "function") {
       try { screenly.signalReady(); } catch (e) {}
     }
   });
@@ -413,6 +416,7 @@ mod wrap_tests {
         assert!(wrapped.contains(SIGNAGE_STYLE_MARKER));
         assert!(wrapped.contains("[role=\"tab\"]"));
         assert!(wrapped.contains("DWELL_MS"));
+        assert!(wrapped.contains("signalReadyForRendering"));
     }
 
     #[test]

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -1,7 +1,44 @@
 //! Edge App MCP tools.
 
+use std::fs;
+
+use serde_json::json;
+
 use crate::authentication::Authentication;
 use crate::commands;
+use crate::commands::edge_app::manifest::{
+    EdgeAppManifest, Entrypoint, EntrypointType, MANIFEST_VERSION,
+};
+use crate::commands::edge_app::EdgeAppCommand;
+
+/// Marker attribute so wrap is idempotent when HTML is published again.
+pub(crate) const THEME_BOOTSTRAP_MARKER: &str = "data-screenly-mcp-theme";
+
+const SCREENLY_JS_SRC: &str = "screenly.js?version=1";
+
+/// Theme bootstrap aligned with `@screenly/edge-apps` `setupTheme()`:
+/// map Screenly branding settings onto CSS custom properties, then signal ready.
+const THEME_BOOTSTRAP_SCRIPT: &str = r#"<script data-screenly-mcp-theme="1">
+(function () {
+  var settings = (window.screenly && screenly.settings) || {};
+  var root = document.documentElement;
+  function setVar(name, value) {
+    if (value) root.style.setProperty(name, value);
+  }
+  var accent = settings.screenly_color_accent;
+  var light = settings.screenly_color_light;
+  var dark = settings.screenly_color_dark;
+  setVar("--screenly-color-accent", accent);
+  setVar("--screenly-color-light", light);
+  setVar("--screenly-color-dark", dark);
+  setVar("--theme-color-accent", accent);
+  setVar("--theme-color-light", light);
+  setVar("--theme-color-dark", dark);
+  if (window.screenly && typeof screenly.signalReady === "function") {
+    try { screenly.signalReady(); } catch (e) {}
+  }
+})();
+</script>"#;
 
 /// Edge App tools for the MCP server.
 pub struct EdgeAppTools;
@@ -40,5 +77,207 @@ impl EdgeAppTools {
 
         serde_json::to_string_pretty(&result)
             .map_err(|e| format!("Failed to serialize response: {}", e))
+    }
+
+    /// Create or update an Edge App from HTML (Claude Artifact / webpage).
+    ///
+    /// Omitting `app_id` creates a new app. Passing `app_id` deploys a new revision,
+    /// the same as `screenly edge-app deploy`.
+    pub fn publish_from_html(
+        auth: &Authentication,
+        name: &str,
+        html: &str,
+        app_id: Option<&str>,
+        description: Option<&str>,
+    ) -> Result<String, String> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err("name is required".to_string());
+        }
+
+        let wrapped = wrap_html_for_edge_app(html)?;
+        let dir = tempfile::tempdir()
+            .map_err(|e| format!("Failed to create temporary Edge App directory: {e}"))?;
+        let dir_path = dir.path();
+
+        fs::write(dir_path.join("index.html"), &wrapped)
+            .map_err(|e| format!("Failed to write index.html: {e}"))?;
+
+        let existing_id = app_id
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(ToOwned::to_owned);
+
+        let created = existing_id.is_none();
+        let manifest = EdgeAppManifest {
+            syntax: MANIFEST_VERSION.to_owned(),
+            id: existing_id.clone(),
+            description: description
+                .map(str::trim)
+                .filter(|d| !d.is_empty())
+                .map(ToOwned::to_owned),
+            ready_signal: Some(true),
+            entrypoint: Some(Entrypoint {
+                entrypoint_type: EntrypointType::File,
+                uri: None,
+            }),
+            ..Default::default()
+        };
+
+        let manifest_path = dir_path.join("screenly.yml");
+        EdgeAppManifest::save_to_file(&manifest, &manifest_path)
+            .map_err(|e| format!("Failed to write screenly.yml: {e}"))?;
+
+        let command = edge_app_command(auth);
+        if created {
+            command
+                .create_in_place(name, &manifest_path)
+                .map_err(|e| format!("Failed to create Edge App: {e}"))?;
+        }
+
+        let app_id = EdgeAppManifest::new(&manifest_path)
+            .map_err(|e| format!("Failed to read Edge App id: {e}"))?
+            .id
+            .ok_or_else(|| "Edge App id missing after create".to_string())?;
+
+        let path = dir_path
+            .to_str()
+            .ok_or_else(|| "Edge App path is not valid UTF-8".to_string())?
+            .to_string();
+
+        let revision = command
+            .deploy(Some(path), Some(false))
+            .map_err(|e| format!("Failed to deploy Edge App: {e}"))?;
+
+        serde_json::to_string_pretty(&json!({
+            "app_id": app_id,
+            "name": name,
+            "revision": revision,
+            "created": created,
+            "message": "Reuse app_id with this tool to publish an HTML update as a new Edge App revision.",
+        }))
+        .map_err(|e| format!("Failed to serialize response: {e}"))
+    }
+}
+
+fn edge_app_command(auth: &Authentication) -> EdgeAppCommand {
+    EdgeAppCommand::new(Authentication {
+        config: crate::authentication::Config {
+            url: auth.config.url.clone(),
+        },
+        token: auth.token.clone(),
+    })
+}
+
+/// Turn a Claude Artifact / HTML fragment into a player-ready Edge App document.
+pub(crate) fn wrap_html_for_edge_app(html: &str) -> Result<String, String> {
+    let html = html.trim();
+    if html.is_empty() {
+        return Err("html is empty".to_string());
+    }
+
+    let screenly_script = format!(r#"<script src="{SCREENLY_JS_SRC}"></script>"#);
+    let lower = html.to_ascii_lowercase();
+    let has_html_shell = lower.contains("<html") && lower.contains("</html>");
+
+    if !has_html_shell {
+        return Ok(format!(
+            "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n{screenly_script}\n</head>\n<body>\n{html}\n{THEME_BOOTSTRAP_SCRIPT}\n</body>\n</html>\n"
+        ));
+    }
+
+    let mut out = html.to_string();
+
+    if !lower.contains("screenly.js") {
+        out = inject_before_tag(&out, "</head>", &format!("{screenly_script}\n"))
+            .or_else(|| inject_after_tag(&out, "<head>", &format!("\n{screenly_script}\n")))
+            .ok_or_else(|| {
+                "HTML document is missing a <head> element to inject screenly.js".to_string()
+            })?;
+    }
+
+    if !out.contains(THEME_BOOTSTRAP_MARKER) {
+        out = inject_before_tag(&out, "</body>", &format!("{THEME_BOOTSTRAP_SCRIPT}\n"))
+            .or_else(|| inject_before_tag(&out, "</html>", &format!("{THEME_BOOTSTRAP_SCRIPT}\n")))
+            .ok_or_else(|| {
+                "HTML document is missing a </body> or </html> tag to inject theme bootstrap"
+                    .to_string()
+            })?;
+    }
+
+    if !out.to_ascii_lowercase().contains("<!doctype") {
+        out = format!("<!DOCTYPE html>\n{out}");
+    }
+
+    Ok(out)
+}
+
+fn inject_before_tag(html: &str, tag: &str, snippet: &str) -> Option<String> {
+    let idx = find_ascii_ignore_case(html, tag)?;
+    let mut out = String::with_capacity(html.len() + snippet.len());
+    out.push_str(&html[..idx]);
+    out.push_str(snippet);
+    out.push_str(&html[idx..]);
+    Some(out)
+}
+
+fn inject_after_tag(html: &str, tag: &str, snippet: &str) -> Option<String> {
+    let idx = find_ascii_ignore_case(html, tag)?;
+    let insert_at = idx + tag.len();
+    let mut out = String::with_capacity(html.len() + snippet.len());
+    out.push_str(&html[..insert_at]);
+    out.push_str(snippet);
+    out.push_str(&html[insert_at..]);
+    Some(out)
+}
+
+fn find_ascii_ignore_case(haystack: &str, needle: &str) -> Option<usize> {
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .position(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
+#[cfg(test)]
+mod wrap_tests {
+    use super::*;
+
+    #[test]
+    fn wrap_fragment_adds_shell_screenly_js_and_theme() {
+        let wrapped = wrap_html_for_edge_app("<h1>Hello</h1>").unwrap();
+        assert!(wrapped.contains("<!DOCTYPE html>"));
+        assert!(wrapped.contains(SCREENLY_JS_SRC));
+        assert!(wrapped.contains(THEME_BOOTSTRAP_MARKER));
+        assert!(wrapped.contains("<h1>Hello</h1>"));
+        assert!(wrapped.contains("--screenly-color-accent"));
+    }
+
+    #[test]
+    fn wrap_full_document_injects_into_existing_head_and_body() {
+        let html = r#"<!DOCTYPE html>
+<html>
+<head><title>Board</title></head>
+<body><p>News</p></body>
+</html>"#;
+        let wrapped = wrap_html_for_edge_app(html).unwrap();
+        assert!(wrapped.contains(SCREENLY_JS_SRC));
+        assert!(wrapped.contains("<title>Board</title>"));
+        assert!(wrapped.contains("<p>News</p>"));
+        let js_pos = wrapped.find(SCREENLY_JS_SRC).unwrap();
+        let head_close = wrapped.to_ascii_lowercase().find("</head>").unwrap();
+        assert!(js_pos < head_close);
+    }
+
+    #[test]
+    fn wrap_is_idempotent_for_screenly_js_and_theme() {
+        let once = wrap_html_for_edge_app("<div>Hi</div>").unwrap();
+        let twice = wrap_html_for_edge_app(&once).unwrap();
+        assert_eq!(twice.matches(SCREENLY_JS_SRC).count(), 1);
+        assert_eq!(twice.matches(THEME_BOOTSTRAP_MARKER).count(), 1);
+    }
+
+    #[test]
+    fn wrap_rejects_empty_html() {
+        assert!(wrap_html_for_edge_app("   ").is_err());
     }
 }

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -18,6 +18,10 @@ use crate::commands::edge_app::EdgeAppCommand;
 /// Override path for the local name → app/instance cache (used in tests).
 const MCP_EDGE_APPS_PATH_ENV: &str = "SCREENLY_MCP_EDGE_APPS_PATH";
 
+/// Default Edge App icon for Claude Artifact publishes (screenly.yml `icon`).
+const DEFAULT_CLAUDE_APP_ICON: &str =
+    "https://playground.srly.io/edge-apps/icons/claude-app-default.svg";
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct McpEdgeAppRecord {
     app_id: String,
@@ -257,6 +261,7 @@ impl EdgeAppTools {
                 .map(str::trim)
                 .filter(|d| !d.is_empty())
                 .map(ToOwned::to_owned),
+            icon: Some(DEFAULT_CLAUDE_APP_ICON.to_owned()),
             ready_signal: Some(true),
             entrypoint: Some(Entrypoint {
                 entrypoint_type: EntrypointType::File,

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -1,6 +1,7 @@
 //! Edge App MCP tools.
 
 use std::fs;
+use std::path::Path;
 
 use serde_json::json;
 
@@ -13,11 +14,18 @@ use crate::commands::edge_app::EdgeAppCommand;
 
 /// Marker attribute so wrap is idempotent when HTML is published again.
 const THEME_BOOTSTRAP_MARKER: &str = "data-screenly-mcp-theme";
+const SIGNAGE_STYLE_MARKER: &str = "data-screenly-mcp-signage";
 
 const SCREENLY_JS_SRC: &str = "screenly.js?version=1";
 
-/// Theme bootstrap aligned with `@screenly/edge-apps` `setupTheme()`:
-/// map Screenly branding settings onto CSS custom properties, then signal ready.
+const SIGNAGE_STYLE: &str = r#"<style data-screenly-mcp-signage="1">
+html, body { height: 100%; margin: 0; }
+html { -webkit-user-select: none; user-select: none; }
+a, button, [role="tab"], [role="button"] { cursor: default; }
+</style>"#;
+
+/// Theme + unattended signage: branding CSS variables, then auto-show tiles/pages
+/// that would otherwise need a mouse or keyboard.
 const THEME_BOOTSTRAP_SCRIPT: &str = r#"<script data-screenly-mcp-theme="1">
 (function () {
   var settings = (window.screenly && screenly.settings) || {};
@@ -34,9 +42,111 @@ const THEME_BOOTSTRAP_SCRIPT: &str = r#"<script data-screenly-mcp-theme="1">
   setVar("--theme-color-accent", accent);
   setVar("--theme-color-light", light);
   setVar("--theme-color-dark", dark);
-  if (window.screenly && typeof screenly.signalReady === "function") {
-    try { screenly.signalReady(); } catch (e) {}
+
+  var DWELL_MS = 8000;
+
+  function isHidden(el) {
+    if (!el || el.nodeType !== 1) return true;
+    if (el.hasAttribute("hidden")) return true;
+    var s = window.getComputedStyle(el);
+    return s.display === "none" || s.visibility === "hidden";
   }
+
+  function showOnly(items, index) {
+    items.forEach(function (el, i) {
+      var on = i === index;
+      if (on) el.removeAttribute("hidden");
+      else el.setAttribute("hidden", "");
+      el.style.display = on ? "" : "none";
+      el.setAttribute("aria-hidden", on ? "false" : "true");
+      el.classList.toggle("active", on);
+      el.classList.toggle("show", on);
+    });
+  }
+
+  function collectPages() {
+    var panels = document.querySelectorAll('[role="tabpanel"]');
+    if (panels.length > 1) return Array.prototype.slice.call(panels);
+    var selectors = [
+      ".slide", ".carousel-item", ".page", ".tile", ".view",
+      "[data-page]", "[data-slide]", "[data-view]"
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+      var found = document.querySelectorAll(selectors[i]);
+      if (found.length > 1) return Array.prototype.slice.call(found);
+    }
+    var nodes = document.querySelectorAll("body *");
+    for (var j = 0; j < nodes.length; j++) {
+      var parent = nodes[j];
+      var kids = [];
+      for (var k = 0; k < parent.children.length; k++) {
+        var child = parent.children[k];
+        var tag = child.tagName;
+        if (tag === "SCRIPT" || tag === "STYLE" || tag === "LINK" || tag === "META") continue;
+        kids.push(child);
+      }
+      if (kids.length < 2) continue;
+      var hiddenCount = kids.filter(isHidden).length;
+      if (hiddenCount >= 1 && hiddenCount < kids.length) return kids;
+    }
+    return [];
+  }
+
+  function startSignage() {
+    document.querySelectorAll("details").forEach(function (el) { el.open = true; });
+    document.querySelectorAll("dialog").forEach(function (el) {
+      try { if (typeof el.show === "function") el.show(); }
+      catch (e) { el.setAttribute("open", ""); }
+    });
+
+    var tabs = document.querySelectorAll('[role="tab"]');
+    if (tabs.length > 1) {
+      var tabIndex = 0;
+      try { tabs[0].click(); } catch (e) {}
+      setInterval(function () {
+        tabIndex = (tabIndex + 1) % tabs.length;
+        try { tabs[tabIndex].click(); } catch (e) {}
+      }, DWELL_MS);
+      return;
+    }
+
+    var pages = collectPages();
+    if (pages.length > 1) {
+      var pageIndex = 0;
+      showOnly(pages, 0);
+      setInterval(function () {
+        pageIndex = (pageIndex + 1) % pages.length;
+        showOnly(pages, pageIndex);
+      }, DWELL_MS);
+      return;
+    }
+
+    var scroller = document.scrollingElement || document.documentElement;
+    if (scroller && scroller.scrollHeight > scroller.clientHeight + 40) {
+      var dir = 1;
+      setInterval(function () {
+        var max = scroller.scrollHeight - scroller.clientHeight;
+        scroller.scrollTop += dir;
+        if (scroller.scrollTop >= max) dir = -1;
+        if (scroller.scrollTop <= 0) dir = 1;
+      }, 40);
+    }
+  }
+
+  function onReady(fn) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", fn);
+    } else {
+      fn();
+    }
+  }
+
+  onReady(function () {
+    try { startSignage(); } catch (e) {}
+    if (window.screenly && typeof screenly.signalReady === "function") {
+      try { screenly.signalReady(); } catch (e) {}
+    }
+  });
 })();
 </script>"#;
 
@@ -149,15 +259,45 @@ impl EdgeAppTools {
             .deploy(Some(path), Some(false))
             .map_err(|e| format!("Failed to deploy Edge App: {}", e))?;
 
+        let (instance_id, instance_created) =
+            ensure_instance(auth, &app_id, name, &dir_path.join("instance.yml"))?;
+
         serde_json::to_string_pretty(&json!({
             "app_id": app_id,
+            "instance_id": instance_id,
+            "instance_created": instance_created,
             "name": name,
             "revision": revision,
             "created": created,
-            "message": "Reuse app_id with this tool to publish an HTML update as a new Edge App revision.",
+            "message": "The instance appears in Screenly Content and can be scheduled on a screen. Reuse app_id to publish an HTML update as a new revision.",
         }))
         .map_err(|e| format!("Failed to serialize response: {}", e))
     }
+}
+
+fn ensure_instance(
+    auth: &Authentication,
+    app_id: &str,
+    name: &str,
+    instance_manifest_path: &Path,
+) -> Result<(Option<String>, bool), String> {
+    let command = edge_app_command(auth);
+    let listed = command
+        .list_instances(app_id)
+        .map_err(|e| format!("Failed to list Edge App instances: {}", e))?;
+
+    if let Some(id) = listed.value.as_array().and_then(|rows| {
+        rows.iter()
+            .find_map(|row| row.get("id").and_then(|v| v.as_str()))
+            .map(ToOwned::to_owned)
+    }) {
+        return Ok((Some(id), false));
+    }
+
+    let instance_id = command
+        .create_instance(instance_manifest_path, app_id, name)
+        .map_err(|e| format!("Failed to create Edge App instance: {}", e))?;
+    Ok((Some(instance_id), true))
 }
 
 fn edge_app_command(auth: &Authentication) -> EdgeAppCommand {
@@ -188,6 +328,7 @@ pub(crate) fn wrap_html_for_edge_app(html: &str) -> Result<String, String> {
              <meta charset=\"utf-8\">\n\
              <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n\
              {screenly_script}\n\
+             {SIGNAGE_STYLE}\n\
              </head>\n\
              <body>\n\
              {html}\n\
@@ -204,6 +345,14 @@ pub(crate) fn wrap_html_for_edge_app(html: &str) -> Result<String, String> {
             .or_else(|| inject_after_tag(&out, "<head>", &format!("\n{screenly_script}\n")))
             .ok_or_else(|| {
                 "HTML document is missing a <head> element to inject screenly.js".to_string()
+            })?;
+    }
+
+    if !out.contains(SIGNAGE_STYLE_MARKER) {
+        out = inject_before_tag(&out, "</head>", &format!("{SIGNAGE_STYLE}\n"))
+            .or_else(|| inject_after_tag(&out, "<head>", &format!("\n{SIGNAGE_STYLE}\n")))
+            .ok_or_else(|| {
+                "HTML document is missing a <head> element to inject signage styles".to_string()
             })?;
     }
 
@@ -261,6 +410,9 @@ mod wrap_tests {
         assert!(wrapped.contains(THEME_BOOTSTRAP_MARKER));
         assert!(wrapped.contains("<h1>Hello</h1>"));
         assert!(wrapped.contains("--screenly-color-accent"));
+        assert!(wrapped.contains(SIGNAGE_STYLE_MARKER));
+        assert!(wrapped.contains("[role=\"tab\"]"));
+        assert!(wrapped.contains("DWELL_MS"));
     }
 
     #[test]
@@ -285,6 +437,7 @@ mod wrap_tests {
         let twice = wrap_html_for_edge_app(&once).unwrap();
         assert_eq!(twice.matches(SCREENLY_JS_SRC).count(), 1);
         assert_eq!(twice.matches(THEME_BOOTSTRAP_MARKER).count(), 1);
+        assert_eq!(twice.matches(SIGNAGE_STYLE_MARKER).count(), 1);
     }
 
     #[test]

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -53,8 +53,8 @@ html { -webkit-user-select: none; user-select: none; }
 a, button, [role="tab"], [role="button"] { cursor: default; }
 </style>"#;
 
-/// Theme + unattended signage: branding CSS variables, then auto-show tiles/pages
-/// that would otherwise need a mouse or keyboard.
+/// Theme CSS variables, then rotate only explicit slideshow markers
+/// (`[role="tabpanel"]`, `.carousel-item`, `[data-slide]`, `[data-screenly-page]`).
 const THEME_BOOTSTRAP_SCRIPT: &str = r#"<script data-screenly-mcp-theme="1">
 (function () {
   var settings = (window.screenly && screenly.settings) || {};
@@ -74,19 +74,20 @@ const THEME_BOOTSTRAP_SCRIPT: &str = r#"<script data-screenly-mcp-theme="1">
 
   var DWELL_MS = 8000;
 
-  function isHidden(el) {
-    if (!el || el.nodeType !== 1) return true;
-    if (el.hasAttribute("hidden")) return true;
-    var s = window.getComputedStyle(el);
-    return s.display === "none" || s.visibility === "hidden";
-  }
-
   function showOnly(items, index) {
     items.forEach(function (el, i) {
       var on = i === index;
-      if (on) el.removeAttribute("hidden");
-      else el.setAttribute("hidden", "");
-      el.style.display = on ? "" : "none";
+      if (!el.hasAttribute("data-screenly-orig-display")) {
+        el.setAttribute("data-screenly-orig-display", el.style.display);
+      }
+      var orig = el.getAttribute("data-screenly-orig-display");
+      if (on) {
+        el.removeAttribute("hidden");
+        el.style.display = (orig && orig !== "none") ? orig : "block";
+      } else {
+        el.setAttribute("hidden", "");
+        el.style.display = "none";
+      }
       el.setAttribute("aria-hidden", on ? "false" : "true");
       el.classList.toggle("active", on);
       el.classList.toggle("show", on);
@@ -94,40 +95,20 @@ const THEME_BOOTSTRAP_SCRIPT: &str = r#"<script data-screenly-mcp-theme="1">
   }
 
   function collectPages() {
-    var panels = document.querySelectorAll('[role="tabpanel"]');
-    if (panels.length > 1) return Array.prototype.slice.call(panels);
     var selectors = [
-      ".slide", ".carousel-item", ".page", ".tile", ".view",
-      "[data-page]", "[data-slide]", "[data-view]"
+      '[role="tabpanel"]',
+      ".carousel-item",
+      "[data-slide]",
+      "[data-screenly-page]"
     ];
     for (var i = 0; i < selectors.length; i++) {
       var found = document.querySelectorAll(selectors[i]);
       if (found.length > 1) return Array.prototype.slice.call(found);
     }
-    var nodes = document.querySelectorAll("body *");
-    for (var j = 0; j < nodes.length; j++) {
-      var parent = nodes[j];
-      var kids = [];
-      for (var k = 0; k < parent.children.length; k++) {
-        var child = parent.children[k];
-        var tag = child.tagName;
-        if (tag === "SCRIPT" || tag === "STYLE" || tag === "LINK" || tag === "META") continue;
-        kids.push(child);
-      }
-      if (kids.length < 2) continue;
-      var hiddenCount = kids.filter(isHidden).length;
-      if (hiddenCount >= 1 && hiddenCount < kids.length) return kids;
-    }
     return [];
   }
 
   function startSignage() {
-    document.querySelectorAll("details").forEach(function (el) { el.open = true; });
-    document.querySelectorAll("dialog").forEach(function (el) {
-      try { if (typeof el.show === "function") el.show(); }
-      catch (e) { el.setAttribute("open", ""); }
-    });
-
     var tabs = document.querySelectorAll('[role="tab"]');
     if (tabs.length > 1) {
       var tabIndex = 0;
@@ -239,6 +220,7 @@ impl EdgeAppTools {
         }
 
         let wrapped = wrap_html_for_edge_app(html)?;
+        let ready_signal = has_screenly_js_script(&wrapped);
         let dir = tempfile::tempdir()
             .map_err(|e| format!("Failed to create temporary Edge App directory: {}", e))?;
         let dir_path = dir.path();
@@ -267,7 +249,7 @@ impl EdgeAppTools {
                 .filter(|d| !d.is_empty())
                 .map(ToOwned::to_owned),
             icon: Some(DEFAULT_CLAUDE_APP_ICON.to_owned()),
-            ready_signal: Some(true),
+            ready_signal: Some(ready_signal),
             entrypoint: Some(Entrypoint {
                 entrypoint_type: EntrypointType::File,
                 uri: None,
@@ -547,7 +529,7 @@ pub(crate) fn wrap_html_for_edge_app(html: &str) -> Result<String, String> {
 
     let mut out = html.to_string();
 
-    if !lower.contains("screenly.js") {
+    if !has_screenly_js_script(&out) {
         out = inject_before_tag(&out, "</head>", &format!("{screenly_script}\n"))
             .or_else(|| inject_after_tag(&out, "<head>", &format!("\n{screenly_script}\n")))
             .ok_or_else(|| {
@@ -577,6 +559,23 @@ pub(crate) fn wrap_html_for_edge_app(html: &str) -> Result<String, String> {
     }
 
     Ok(out)
+}
+
+/// True when an opening `<script src=…>` tag points at `screenly.js`.
+/// A comment or code sample that merely mentions the filename does not count.
+fn has_screenly_js_script(html: &str) -> bool {
+    let lower = html.to_ascii_lowercase();
+    let mut rest = lower.as_str();
+    while let Some(idx) = rest.find("<script") {
+        let after = &rest[idx + 7..];
+        let tag_end = after.find('>').unwrap_or(after.len());
+        let tag = &after[..tag_end];
+        if tag.contains("src=") && tag.contains("screenly.js") {
+            return true;
+        }
+        rest = after;
+    }
+    false
 }
 
 fn inject_before_tag(html: &str, tag: &str, snippet: &str) -> Option<String> {
@@ -621,6 +620,10 @@ mod wrap_tests {
         assert!(wrapped.contains("[role=\"tab\"]"));
         assert!(wrapped.contains("DWELL_MS"));
         assert!(wrapped.contains("signalReadyForRendering"));
+        assert!(wrapped.contains("data-screenly-orig-display"));
+        assert!(!wrapped.contains(".tile"));
+        assert!(!wrapped.contains("querySelectorAll(\"dialog\")"));
+        assert!(!wrapped.contains("querySelectorAll(\"body *\")"));
     }
 
     #[test]
@@ -651,6 +654,42 @@ mod wrap_tests {
     #[test]
     fn wrap_rejects_empty_html() {
         assert!(wrap_html_for_edge_app("   ").is_err());
+    }
+
+    #[test]
+    fn wrap_injects_screenly_js_when_filename_only_appears_in_a_comment() {
+        let html = r#"<!DOCTYPE html>
+<html>
+<head>
+<!-- loads screenly.js on the player -->
+<title>Board</title>
+</head>
+<body><p>News</p></body>
+</html>"#;
+        let wrapped = wrap_html_for_edge_app(html).unwrap();
+        assert_eq!(wrapped.matches(SCREENLY_JS_SRC).count(), 1);
+        assert!(has_screenly_js_script(&wrapped));
+    }
+
+    #[test]
+    fn wrap_skips_inject_when_script_src_already_loads_screenly_js() {
+        let html = r#"<!DOCTYPE html>
+<html>
+<head>
+<script src="screenly.js?version=1"></script>
+<title>Board</title>
+</head>
+<body><p>News</p></body>
+</html>"#;
+        let wrapped = wrap_html_for_edge_app(html).unwrap();
+        assert_eq!(wrapped.matches("screenly.js").count(), 1);
+        assert!(has_screenly_js_script(&wrapped));
+    }
+
+    #[test]
+    fn has_screenly_js_script_ignores_inline_script_text() {
+        let html = r#"<script>console.log("screenly.js")</script>"#;
+        assert!(!has_screenly_js_script(html));
     }
 }
 

--- a/src/mcp/tools/edge_app.rs
+++ b/src/mcp/tools/edge_app.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::authentication::Authentication;
 use crate::commands;
@@ -35,9 +36,9 @@ struct McpEdgeAppRecord {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct McpEdgeAppRegistry {
-    /// Exact display name → last published Edge App / instance.
+    /// `{api_url}|{token fingerprint}` → display name → last published ids.
     #[serde(default)]
-    apps: BTreeMap<String, McpEdgeAppRecord>,
+    scopes: BTreeMap<String, BTreeMap<String, McpEdgeAppRecord>>,
 }
 
 /// Marker attribute so wrap is idempotent when HTML is published again.
@@ -250,7 +251,7 @@ impl EdgeAppTools {
             .filter(|id| !id.is_empty())
             .map(ToOwned::to_owned);
         let remembered = if explicit_id.is_none() {
-            lookup_remembered_app(name)
+            lookup_remembered_app(auth, name)
         } else {
             None
         };
@@ -310,13 +311,14 @@ impl EdgeAppTools {
                 }
             };
 
-        let saved_to_memory = match remember_published_app(name, &app_id, instance_id.as_deref()) {
-            Ok(()) => true,
-            Err(e) => {
-                warnings.push(format!("Failed to save app_id locally: {e}"));
-                false
-            }
-        };
+        let saved_to_memory =
+            match remember_published_app(auth, name, &app_id, instance_id.as_deref()) {
+                Ok(()) => true,
+                Err(e) => {
+                    warnings.push(format!("Failed to save app_id locally: {e}"));
+                    false
+                }
+            };
 
         serialize_publish_success(PublishFromHtmlResponse {
             app_id,
@@ -402,24 +404,82 @@ fn save_registry(registry: &McpEdgeAppRegistry) -> Result<(), String> {
         .map_err(|e| format!("Failed to write {}: {}", path.display(), e))
 }
 
-fn lookup_remembered_app(name: &str) -> Option<McpEdgeAppRecord> {
-    load_registry().ok()?.apps.get(name).cloned()
+fn registry_scope(auth: &Authentication) -> String {
+    let url = auth.config.url.trim().trim_end_matches('/');
+    format!("{url}|{}", token_fingerprint(&auth.token))
+}
+
+fn token_fingerprint(token: &str) -> String {
+    hex::encode(Sha256::digest(token.trim().as_bytes()))
+}
+
+fn lookup_in_registry(auth: &Authentication, name: &str) -> Option<McpEdgeAppRecord> {
+    load_registry()
+        .ok()?
+        .scopes
+        .get(&registry_scope(auth))?
+        .get(name)
+        .cloned()
+}
+
+/// Returns the remembered ids for this API host + token, or `None` if the app
+/// is gone (entry is then dropped). Network errors keep the cached id.
+fn lookup_remembered_app(auth: &Authentication, name: &str) -> Option<McpEdgeAppRecord> {
+    let record = lookup_in_registry(auth, name)?;
+    match app_exists_in_account(auth, &record.app_id) {
+        Ok(true) => Some(record),
+        Ok(false) => {
+            let _ = forget_published_app(auth, name);
+            None
+        }
+        Err(_) => Some(record),
+    }
 }
 
 fn remember_published_app(
+    auth: &Authentication,
     name: &str,
     app_id: &str,
     instance_id: Option<&str>,
 ) -> Result<(), String> {
     let mut registry = load_registry()?;
-    registry.apps.insert(
-        name.to_string(),
-        McpEdgeAppRecord {
-            app_id: app_id.to_string(),
-            instance_id: instance_id.map(ToOwned::to_owned),
-        },
-    );
+    registry
+        .scopes
+        .entry(registry_scope(auth))
+        .or_default()
+        .insert(
+            name.to_string(),
+            McpEdgeAppRecord {
+                app_id: app_id.to_string(),
+                instance_id: instance_id.map(ToOwned::to_owned),
+            },
+        );
     save_registry(&registry)
+}
+
+fn forget_published_app(auth: &Authentication, name: &str) -> Result<(), String> {
+    let mut registry = load_registry()?;
+    let scope = registry_scope(auth);
+    let empty = if let Some(apps) = registry.scopes.get_mut(&scope) {
+        apps.remove(name);
+        apps.is_empty()
+    } else {
+        false
+    };
+    if empty {
+        registry.scopes.remove(&scope);
+    }
+    save_registry(&registry)
+}
+
+fn app_exists_in_account(auth: &Authentication, app_id: &str) -> Result<bool, String> {
+    let endpoint = format!("v4/edge-apps?select=id&id=eq.{app_id}&deleted=eq.false");
+    let result = commands::get(auth, &endpoint)
+        .map_err(|e| format!("Failed to look up Edge App {app_id}: {e}"))?;
+    Ok(result
+        .as_array()
+        .map(|rows| !rows.is_empty())
+        .unwrap_or(false))
 }
 
 fn ensure_instance(
@@ -597,25 +657,71 @@ mod wrap_tests {
 #[cfg(test)]
 mod registry_tests {
     use super::*;
+    use crate::authentication::Config;
+    use httpmock::Method::GET;
+    use httpmock::MockServer;
+    use serde_json::json;
     use tempfile::tempdir;
+
+    fn test_auth(url: &str, token: &str) -> Authentication {
+        Authentication::new_with_config(Config::new(url.to_string()), token)
+    }
+
+    fn with_registry<R>(f: impl FnOnce() -> R) -> R {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mcp-edge-apps.json");
+        let path_str = path.to_str().unwrap().to_string();
+        temp_env::with_var(MCP_EDGE_APPS_PATH_ENV, Some(path_str.as_str()), f)
+    }
 
     #[test]
     fn remember_and_lookup_round_trip() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("mcp-edge-apps.json");
-        let path_str = path.to_str().unwrap();
+        with_registry(|| {
+            let auth = test_auth("https://api.example.com", "token-a");
+            assert!(lookup_in_registry(&auth, "Lobby Board").is_none());
+            remember_published_app(&auth, "Lobby Board", "app-1", Some("inst-1")).unwrap();
 
-        temp_env::with_var(MCP_EDGE_APPS_PATH_ENV, Some(path_str), || {
-            assert!(lookup_remembered_app("Lobby Board").is_none());
-            remember_published_app("Lobby Board", "app-1", Some("inst-1")).unwrap();
-
-            let remembered = lookup_remembered_app("Lobby Board").unwrap();
+            let remembered = lookup_in_registry(&auth, "Lobby Board").unwrap();
             assert_eq!(remembered.app_id, "app-1");
             assert_eq!(remembered.instance_id.as_deref(), Some("inst-1"));
 
-            remember_published_app("Lobby Board", "app-1", Some("inst-2")).unwrap();
-            let updated = lookup_remembered_app("Lobby Board").unwrap();
+            remember_published_app(&auth, "Lobby Board", "app-1", Some("inst-2")).unwrap();
+            let updated = lookup_in_registry(&auth, "Lobby Board").unwrap();
             assert_eq!(updated.instance_id.as_deref(), Some("inst-2"));
+        });
+    }
+
+    #[test]
+    fn registry_is_scoped_by_api_url_and_token() {
+        with_registry(|| {
+            let prod_a = test_auth("https://api.example.com", "token-a");
+            let prod_b = test_auth("https://api.example.com", "token-b");
+            let staging_a = test_auth("https://staging.example.com", "token-a");
+
+            remember_published_app(&prod_a, "Lobby Board", "app-prod-a", None).unwrap();
+
+            assert!(lookup_in_registry(&prod_b, "Lobby Board").is_none());
+            assert!(lookup_in_registry(&staging_a, "Lobby Board").is_none());
+            assert_eq!(
+                lookup_in_registry(&prod_a, "Lobby Board").unwrap().app_id,
+                "app-prod-a"
+            );
+        });
+    }
+
+    #[test]
+    fn stale_remembered_id_is_forgotten() {
+        with_registry(|| {
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(GET).path("/v4/edge-apps");
+                then.status(200).json_body(json!([]));
+            });
+            let auth = test_auth(&server.base_url(), "token-a");
+            remember_published_app(&auth, "Lobby Board", "gone-app", None).unwrap();
+            assert!(lookup_in_registry(&auth, "Lobby Board").is_some());
+            assert!(lookup_remembered_app(&auth, "Lobby Board").is_none());
+            assert!(lookup_in_registry(&auth, "Lobby Board").is_none());
         });
     }
 


### PR DESCRIPTION
## Summary
- Stacked on #304 (`feat/mcp-annotations-and-mcpb-bundle`). This PR only adds the HTML → Edge App publish path.
- Adds `edge_app_publish_from_html` so Claude can turn Artifact / webpage HTML into a Screenly Edge App (`screenly.js` + theme CSS variables).
- Omit `app_id` to create; pass `app_id` to deploy a new revision (same as `screenly edge-app deploy`). Phrasing like “upload this as a Screenly app” maps to the same tool.

## Test plan
- [ ] `cargo check` and `cargo clippy -- -D warnings`
- [ ] `cargo test --bin screenly mcp::`
- [X] In Claude: “upload this as a Screenly app named Lobby Board”
- [X] Ask Claude to update the same app and confirm a new revision


## Demo 

1. Use MCP to list Screenly players and stats
<img width="2538" height="1812" alt="2026-08-20_13-40" src="https://github.com/user-attachments/assets/6a774861-b558-4417-8a3a-9f78065a3a5d" />

2. Ask Claude to create a website to visualize 
<img width="2540" height="1808" alt="2026-08-20_13-24" src="https://github.com/user-attachments/assets/2df97bdd-879d-4698-8623-2c87f550c210" />

3. Ask to create a Screenly App/Edge App based on the view

<img width="2528" height="1458" alt="2026-08-20_13-32" src="https://github.com/user-attachments/assets/95ebe9a3-34b6-42da-a666-afaa307e39a7" />

3.1 Edge App Installation is ready to be added to the playlist. 
<img width="2858" height="1210" alt="2026-08-20_13-28" src="https://github.com/user-attachments/assets/7fd3a218-27be-4b3f-a421-43a241ba488f" />
3.2 Apps running on Screenly anywhere
<img width="3420" height="2214" alt="2026-08-20_13-30" src="https://github.com/user-attachments/assets/91b640cc-0c91-4fb2-9fba-2571a254c480" />

4. Ask to make some modifications

<img width="1648" height="1064" alt="2026-08-20_13-38" src="https://github.com/user-attachments/assets/c026215d-3b32-45fa-893f-a61124e0e1ac" />
4.1 Modified app uploaded and running on Screenly anywhere. 
<img width="3420" height="2214" alt="2026-08-20_13-37" src="https://github.com/user-attachments/assets/21642a49-00c2-4dfa-a44b-7f51d5e385bc" />

