### PR TITLE
Rename setting priority field to display_order

### DIFF
--- a/docs/EdgeApps.md
+++ b/docs/EdgeApps.md
@@ -483,6 +483,7 @@ Edge App settings support additional input field types beyond plain text and pas
   - `properties.type`: One of `datetime`, `number`, `select`, `boolean`, `textarea`, `url`.
   - `properties.help_text`: Human-friendly description shown in the UI.
   - `properties.options` (only for `select`): Array of `{ label, value }` options.
+  - `properties.display_order`: Optional integer controlling the order settings render in the install/edit UI (ascending). If omitted, `screenly edge-app deploy` auto-assigns one from the setting's position in the manifest's `settings:` mapping, so settings render in declaration order by default — set an explicit value only to override that default.
 - **Storage**: Use `type: string` for all non-secret fields; use `type: secret` for password-like fields. The UI will coerce values appropriately (e.g., booleans) but values are stored as strings unless `type: secret`.
 - **Defaults**: Provide `default_value` at the setting level. For booleans, use `'true'` or `'false'` as strings.
 
@@ -586,6 +587,32 @@ settings:
       properties:
         help_text: The URL of the website
         type: url
+```
+
+**Explicit display order override**
+
+```yaml
+settings:
+  number_field:
+    type: string
+    title: Attendee Count
+    optional: false
+    help_text:
+      schema_version: 1
+      properties:
+        help_text: The expected count of attendees
+        type: number
+        display_order: 2
+  date_time_field:
+    type: string
+    title: Start Date Time
+    optional: false
+    help_text:
+      schema_version: 1
+      properties:
+        help_text: The start date and time of the event
+        type: datetime
+        display_order: 1
 ```
 
 Notes:

--- a/src/api/edge_app/setting.rs
+++ b/src/api/edge_app/setting.rs
@@ -256,7 +256,7 @@ const HELP_TEXT_NAME_OVERRIDES: &[&str] = &[
     "theme",
 ];
 
-pub fn help_text_with_priority(name: &str, help_text: &str, priority: usize) -> String {
+pub fn help_text_with_display_order(name: &str, help_text: &str, display_order: usize) -> String {
     if HELP_TEXT_NAME_OVERRIDES.contains(&name) {
         return help_text.to_string();
     }
@@ -273,7 +273,7 @@ pub fn help_text_with_priority(name: &str, help_text: &str, priority: usize) -> 
 
     if is_schema {
         if let Some(properties) = value.get_mut("properties").and_then(Value::as_object_mut) {
-            properties.insert("priority".to_string(), json!(priority));
+            properties.insert("display_order".to_string(), json!(display_order));
         }
         return serde_json::to_string(&value).unwrap_or_else(|_| help_text.to_string());
     }
@@ -282,15 +282,16 @@ pub fn help_text_with_priority(name: &str, help_text: &str, priority: usize) -> 
         "schema_version": 1,
         "properties": {
             "help_text": help_text,
-            "priority": priority,
+            "display_order": display_order,
         }
     })
     .to_string()
 }
 
-pub fn assign_setting_priorities(settings: &mut [Setting]) {
-    for (priority, setting) in settings.iter_mut().enumerate() {
-        setting.help_text = help_text_with_priority(&setting.name, &setting.help_text, priority);
+pub fn assign_setting_display_orders(settings: &mut [Setting]) {
+    for (display_order, setting) in settings.iter_mut().enumerate() {
+        setting.help_text =
+            help_text_with_display_order(&setting.name, &setting.help_text, display_order);
     }
 }
 

--- a/src/commands/edge_app/app.rs
+++ b/src/commands/edge_app/app.rs
@@ -211,7 +211,7 @@ impl EdgeAppCommand {
 
         EdgeAppManifest::ensure_manifest_is_valid(&manifest_path)?;
         let mut manifest = EdgeAppManifest::new(&manifest_path)?;
-        manifest.assign_setting_priorities();
+        manifest.assign_setting_display_orders();
         EdgeAppManifest::save_to_file(&manifest, &manifest_path)?;
 
         let actual_app_id = match self.get_app_id(path.clone()) {
@@ -1195,7 +1195,7 @@ mod tests {
                         "schema_version": 1,
                         "properties": {
                             "help_text": "help text",
-                            "priority": 0,
+                            "display_order": 0,
                         },
                     },
                 }));
@@ -1231,7 +1231,7 @@ mod tests {
                         "schema_version": 1,
                         "properties": {
                             "help_text": "help text",
-                            "priority": 1,
+                            "display_order": 1,
                         },
                     },
                 }));

--- a/src/commands/edge_app/manifest.rs
+++ b/src/commands/edge_app/manifest.rs
@@ -276,8 +276,8 @@ impl EdgeAppManifest {
         Ok(())
     }
 
-    pub fn assign_setting_priorities(&mut self) {
-        crate::api::edge_app::setting::assign_setting_priorities(&mut self.settings);
+    pub fn assign_setting_display_orders(&mut self) {
+        crate::api::edge_app::setting::assign_setting_display_orders(&mut self.settings);
     }
 
     pub fn prepare_payload(manifest: &EdgeAppManifest) -> HashMap<&str, serde_json::Value> {

--- a/src/commands/edge_app/utils.rs
+++ b/src/commands/edge_app/utils.rs
@@ -6,7 +6,7 @@ use log::debug;
 use walkdir::{DirEntry, WalkDir};
 
 use crate::api::asset::AssetSignature;
-use crate::api::edge_app::setting::{assign_setting_priorities, Setting, SettingType};
+use crate::api::edge_app::setting::{assign_setting_display_orders, Setting, SettingType};
 use crate::commands::edge_app::instance_manifest::InstanceManifest;
 use crate::commands::edge_app::manifest::EdgeAppManifest;
 use crate::commands::ignorer::Ignorer;
@@ -221,7 +221,7 @@ pub fn detect_changed_settings(
         }
     }
 
-    assign_setting_priorities(&mut new_settings);
+    assign_setting_display_orders(&mut new_settings);
 
     let remote_by_name: HashMap<&str, &Setting> = remote_settings
         .iter()
@@ -310,7 +310,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::api::edge_app::setting::{help_text_with_priority, Setting, SettingType};
+    use crate::api::edge_app::setting::{help_text_with_display_order, Setting, SettingType};
     use crate::commands::edge_app::instance_manifest::INSTANCE_MANIFEST_VERSION;
     use crate::commands::edge_app::manifest::{Auth, Entrypoint, EntrypointType, MANIFEST_VERSION};
     use crate::commands::edge_app::manifest_auth::AuthType;
@@ -367,7 +367,7 @@ mod tests {
                 title: Some("display time title".to_string()),
                 optional: true,
                 is_global: false,
-                help_text: help_text_with_priority("display_time", "For how long to display the map overlay every time the rover has moved to a new position.", 0),
+                help_text: help_text_with_display_order("display_time", "For how long to display the map overlay every time the rover has moved to a new position.", 0),
             },
             Setting {
                 name: "google_maps_api_key".to_string(),
@@ -376,7 +376,7 @@ mod tests {
                 title: Some("Google maps title".to_string()),
                 optional: true,
                 is_global: false,
-                help_text: help_text_with_priority("google_maps_api_key", "Specify a commercial Google Maps API key. Required due to the app's map feature.", 1),
+                help_text: help_text_with_display_order("google_maps_api_key", "Specify a commercial Google Maps API key. Required due to the app's map feature.", 1),
             },
         ];
 
@@ -402,7 +402,7 @@ mod tests {
                 title: None,
                 optional: true,
                 is_global: false,
-                help_text: help_text_with_priority("display_time", "For how long to display the map overlay every time the rover has moved to a new position.", 0),
+                help_text: help_text_with_display_order("display_time", "For how long to display the map overlay every time the rover has moved to a new position.", 0),
             },
             Setting {
                 name: "google_maps_api_key".to_string(),
@@ -411,7 +411,7 @@ mod tests {
                 title: Some("Google maps title".to_string()),
                 optional: true,
                 is_global: false,
-                help_text: help_text_with_priority("google_maps_api_key", "Specify a commercial Google Maps API key. Required due to the app's map feature.", 1),
+                help_text: help_text_with_display_order("google_maps_api_key", "Specify a commercial Google Maps API key. Required due to the app's map feature.", 1),
             },
         ];
 
@@ -510,7 +510,7 @@ mod tests {
                 title: Some("display time title".to_string()),
                 optional: true,
                 is_global: false,
-                help_text: help_text_with_priority("display_time", "For how long to display the map overlay every time the rover has moved to a new position.", 0),
+                help_text: help_text_with_display_order("display_time", "For how long to display the map overlay every time the rover has moved to a new position.", 0),
             },
             Setting {
                 name: "google_maps_api_key".to_string(),
@@ -519,7 +519,7 @@ mod tests {
                 title: Some("Google maps title".to_string()),
                 optional: true,
                 is_global: false,
-                help_text: help_text_with_priority("google_maps_api_key", "Specify a commercial Google Maps API key. Required due to the app's map feature.", 1),
+                help_text: help_text_with_display_order("google_maps_api_key", "Specify a commercial Google Maps API key. Required due to the app's map feature.", 1),
             },
         ];
 


### PR DESCRIPTION
## Summary
- Renames the `priority` field/identifiers to `display_order` for clarity.