### PR TITLE
Release 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,7 +2893,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screenly"
-version = "1.1.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screenly"
-version = "1.1.1"
+version = "1.2.2"
 edition = "2021"
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3 as builder
 
 WORKDIR /usr/src/screenly-cli
 RUN apk add --no-cache wget tar
-ARG RELEASE=v1.1.1
+ARG RELEASE=v1.2.2
 RUN wget "https://github.com/Screenly/cli/releases/download/$RELEASE/screenly-cli-x86_64-unknown-linux-musl.tar.gz"
 RUN tar xfz screenly-cli-x86_64-unknown-linux-musl.tar.gz
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   cli_version:
     description: "Screenly CLI version."
-    default: "v1.2.1"
+    default: "v1.2.2"
 
 outputs:
   cli_commands_response:


### PR DESCRIPTION
## Summary
- Bump package version to **1.2.2** in `Cargo.toml` / `Cargo.lock`
- Point GitHub Action default `cli_version` at **v1.2.2**
- Point Dockerfile `RELEASE` at **v1.2.2**
- Bring the crate version back in sync with Git tags (it stayed at `1.1.1` through `v1.2.0` / `v1.2.1`)

## What's included since v1.2.1
- [#304](https://github.com/Screenly/cli/pull/304) — MCP annotations + Claude Desktop `.mcpb` marketplace packaging
- [#307](https://github.com/Screenly/cli/pull/307) — `edge_app_publish_from_html` (Claude Artifact HTML → Screenly Edge App)
- [#295](https://github.com/Screenly/cli/pull/295) — arm64 / armhf release binaries
- [#305](https://github.com/Screenly/cli/pull/305) — action.yml default previously bumped to v1.2.1

## After merge
1. On `master`: `git tag v1.2.2 && git push origin v1.2.2`
2. Release workflow builds CLI + `.mcpb` artifacts
3. Add release notes on the GitHub release
4. Update [homebrew-screenly-cli](https://github.com/Screenly/homebrew-screenly-cli)