### PR TITLE
Switch to CalVer and bump version to 26.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,7 +2893,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screenly"
-version = "1.2.2"
+version = "2026.8.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,7 +2893,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screenly"
-version = "2026.8.1"
+version = "26.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screenly"
-version = "1.2.2"
+version = "2026.8.1"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screenly"
-version = "2026.8.1"
+version = "26.8.0"
 edition = "2021"
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3 as builder
 
 WORKDIR /usr/src/screenly-cli
 RUN apk add --no-cache wget tar
-ARG RELEASE=v1.2.2
+ARG RELEASE=v2026.8.1
 RUN wget "https://github.com/Screenly/cli/releases/download/$RELEASE/screenly-cli-x86_64-unknown-linux-musl.tar.gz"
 RUN tar xfz screenly-cli-x86_64-unknown-linux-musl.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3 as builder
 
 WORKDIR /usr/src/screenly-cli
 RUN apk add --no-cache wget tar
-ARG RELEASE=v2026.8.1
+ARG RELEASE=v26.8.0
 RUN wget "https://github.com/Screenly/cli/releases/download/$RELEASE/screenly-cli-x86_64-unknown-linux-musl.tar.gz"
 RUN tar xfz screenly-cli-x86_64-unknown-linux-musl.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ $ mv signature.rs src/pb_signature.rs
 
 ## Release Process
 
-This project follows [Calendar Versioning](https://calver.org/) (`YYYY.M.MICRO` = year, month, and a micro number that starts at `1` for the first release in a given month and increments for any additional release in that same month).
+This project follows [Calendar Versioning](https://calver.org/) (`YY.M.MICRO` = two-digit year, month, and a micro number that starts at `0` for the first release in a given month and increments for any additional release in that same month).
 
-`Cargo.toml`'s `version` field is parsed by Cargo as strict [SemVer](https://semver.org/), which forbids a leading zero in any numeric component. This means the month is **not** zero-padded: August is `8`, not `08` (e.g. `2026.8.1`, not `2026.08.1`).
+`Cargo.toml`'s `version` field is parsed by Cargo as strict [SemVer](https://semver.org/), which forbids a leading zero in any numeric component. This means the month is **not** zero-padded: August is `8`, not `08` (e.g. `26.8.0`, not `26.08.0`).
 
 1. **Prepare the release:**
-  - Figure out the version: use the current year and month, and check existing tags/branches for that year and month (`git tag -l "v$(date +%Y).$(date +%-m).*"`) to pick the next `MICRO` — `1` if none exist yet for this month, otherwise the highest existing `MICRO` plus one.
-  - Create a release branch (e.g., `release-YYYY.M.MICRO`, like `release-2026.8.1`).
+  - Figure out the version: use the current two-digit year and month, and check existing tags/branches for that year and month (`git tag -l "v$(date +%y).$(date +%-m).*"`) to pick the next `MICRO` — `0` if none exist yet for this month, otherwise the highest existing `MICRO` plus one.
+  - Create a release branch (e.g., `release-YY.M.MICRO`, like `release-26.8.0`).
   - Update the version in `Cargo.toml`, `action.yml`, and `Dockerfile`
   - Run `cargo build` to update `Cargo.lock` with the new version
 
@@ -218,10 +218,10 @@ This project follows [Calendar Versioning](https://calver.org/) (`YYYY.M.MICRO` 
 
 3. **Create the GitHub release:**
   - Make sure that you're on the `master` branch and have pulled the latest changes
-  - Create a version tag (e.g., `vYYYY.M.MICRO`, like `v2026.8.1`) and push it to GitHub by running:
+  - Create a version tag (e.g., `vYY.M.MICRO`, like `v26.8.0`) and push it to GitHub by running:
     ```bash
-    git tag vYYYY.M.MICRO
-    git push origin vYYYY.M.MICRO
+    git tag vYY.M.MICRO
+    git push origin vYY.M.MICRO
     ```
   - The release workflow will detect the version tag and create the release automatically
   - Add the release notes to the GitHub release description

--- a/README.md
+++ b/README.md
@@ -202,10 +202,13 @@ $ mv signature.rs src/pb_signature.rs
 
 ## Release Process
 
-This project follows [Semantic Versioning](https://semver.org/) (M.m.p = Major.minor.patch).
+This project follows [Calendar Versioning](https://calver.org/) (`YYYY.M.MICRO` = year, month, and a micro number that starts at `1` for the first release in a given month and increments for any additional release in that same month).
+
+`Cargo.toml`'s `version` field is parsed by Cargo as strict [SemVer](https://semver.org/), which forbids a leading zero in any numeric component. This means the month is **not** zero-padded: August is `8`, not `08` (e.g. `2026.8.1`, not `2026.08.1`).
 
 1. **Prepare the release:**
-  - Create a release branch (e.g., `release-M.m.p`, like `release-1.0.6`).
+  - Figure out the version: use the current year and month, and check existing tags/branches for that year and month (`git tag -l "v$(date +%Y).$(date +%-m).*"`) to pick the next `MICRO` — `1` if none exist yet for this month, otherwise the highest existing `MICRO` plus one.
+  - Create a release branch (e.g., `release-YYYY.M.MICRO`, like `release-2026.8.1`).
   - Update the version in `Cargo.toml`, `action.yml`, and `Dockerfile`
   - Run `cargo build` to update `Cargo.lock` with the new version
 
@@ -215,10 +218,10 @@ This project follows [Semantic Versioning](https://semver.org/) (M.m.p = Major.m
 
 3. **Create the GitHub release:**
   - Make sure that you're on the `master` branch and have pulled the latest changes
-  - Create a version tag (e.g., `vM.m.p`, like `v1.0.6`) and push it to GitHub by running:
+  - Create a version tag (e.g., `vYYYY.M.MICRO`, like `v2026.8.1`) and push it to GitHub by running:
     ```bash
-    git tag vM.m.p
-    git push origin vM.m.p
+    git tag vYYYY.M.MICRO
+    git push origin vYYYY.M.MICRO
     ```
   - The release workflow will detect the version tag and create the release automatically
   - Add the release notes to the GitHub release description

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   cli_version:
     description: "Screenly CLI version."
-    default: "v2026.8.1"
+    default: "v26.8.0"
 
 outputs:
   cli_commands_response:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   cli_version:
     description: "Screenly CLI version."
-    default: "v1.2.2"
+    default: "v2026.8.1"
 
 outputs:
   cli_commands_response:


### PR DESCRIPTION
## What

Switches versioning from SemVer to [CalVer](https://calver.org/): `YY.M.MICRO` (two-digit year, unpadded month, micro starting at `0`). First release under the new scheme: `26.8.0`.

## Why

Cargo parses `Cargo.toml`'s `version` as strict SemVer, which rejects leading zeros — confirmed `26.08.0` fails `cargo check` while `26.8.0` doesn't. So the month stays unpadded everywhere: Cargo.toml, git tag, and `--version` output all match.

## Changes

- `Cargo.toml`, `Cargo.lock`, `action.yml`, `Dockerfile` → `26.8.0`
- README `## Release Process` rewritten for `YY.M.MICRO`, with the leading-zero caveat and how to pick the next `MICRO`