### PR TITLE
Add note in docs that dynamic Edge Apps do not run live on Screenly Anywhere

### DIFF
--- a/docs/EdgeApps.md
+++ b/docs/EdgeApps.md
@@ -214,6 +214,8 @@ $ screenly edge-app instance delete
 
 After creating an instance, navigate to your Screenly web console. You should see the new instance of your Edge App listed in the content section, where you can schedule it as you would with a regular asset.
 
+Dynamic Edge Apps with moving or frequently updating content (animations, clocks, live data, video) will not work properly on Screenly Anywhere. Anywhere uses a screenshot service to display apps and web content, so the screen shows a still image rather than a live, running app. For testing, schedule the instance on a Screenly Player, or run the [Edge App emulator](#edge-app-emulator) locally with `screenly edge-app run`.
+
 ---
 
 #### Instance Manifest

--- a/docs/EdgeApps.md
+++ b/docs/EdgeApps.md
@@ -826,7 +826,7 @@ This metadata includes:
 
 ## Edge App emulator
 
-After creating your Edge App, you can use the Edge App emulator to test it in your web browser.
+After creating your Edge App, you can use the Edge App emulator to test it in your web browser. Use the emulator (or a Screenly Player) when the app has moving or frequently updating content. Screenly Anywhere serves a screenshot, so those apps will not run live there.
 
 * To do this, open your terminal and navigate to the Edge App directory.
 * Run this command:

--- a/docs/EdgeApps.md
+++ b/docs/EdgeApps.md
@@ -828,7 +828,7 @@ This metadata includes:
 
 ## Edge App emulator
 
-After creating your Edge App, you can use the Edge App emulator to test it in your web browser. Use the emulator (or a Screenly Player) when the app has moving or frequently updating content. Screenly Anywhere serves a screenshot, so those apps will not run live there.
+After creating your Edge App, you can use the Edge App emulator to test it in your web browser.
 
 * To do this, open your terminal and navigate to the Edge App directory.
 * Run this command:


### PR DESCRIPTION
## Summary
- Add a note in the Instances section of the Edge Apps guide: apps with moving or frequently updating content will not work properly on Screenly Anywhere.
- Anywhere serves a screenshot of the app, so testers should use a Screenly Player or the Edge App emulator (`screenly edge-app run`).
