### PR TITLE
Bump version to 26.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,7 +2893,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screenly"
-version = "26.8.0"
+version = "26.9.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screenly"
-version = "26.8.0"
+version = "26.9.0"
 edition = "2021"
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3 as builder
 
 WORKDIR /usr/src/screenly-cli
 RUN apk add --no-cache wget tar
-ARG RELEASE=v26.8.0
+ARG RELEASE=v26.9.0
 RUN wget "https://github.com/Screenly/cli/releases/download/$RELEASE/screenly-cli-x86_64-unknown-linux-musl.tar.gz"
 RUN tar xfz screenly-cli-x86_64-unknown-linux-musl.tar.gz
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   cli_version:
     description: "Screenly CLI version."
-    default: "v26.8.0"
+    default: "v26.9.0"
 
 outputs:
   cli_commands_response:


### PR DESCRIPTION
## Summary

- Bumps the version to `26.9.0` (Calendar Versioning: year 26, month 9, first release this month) in `Cargo.toml`, `Cargo.lock`, `action.yml`, and `Dockerfile`, following the documented release process in `README.md`.

## Test plan

- [x] `cargo build`, Cargo.lock regenerated with the new version