### PR TITLE
Dedupe near-duplicate deploy tests

### DIFF
--- a/src/commands/edge_app/app.rs
+++ b/src/commands/edge_app/app.rs
@@ -1073,6 +1073,15 @@ mod tests {
 
     #[test]
     fn test_deploy_should_send_correct_requests() {
+        run_deploy_should_send_correct_requests_test(true);
+    }
+
+    #[test]
+    fn test_deploy_with_explicit_app_id_and_no_manifest_id_should_send_correct_requests() {
+        run_deploy_should_send_correct_requests_test(false);
+    }
+
+    fn run_deploy_should_send_correct_requests_test(id_in_manifest: bool) {
         let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
             prepare_edge_apps_test(false, false);
 
@@ -1097,23 +1106,13 @@ mod tests {
             },
         ]);
 
+        if !id_in_manifest {
+            manifest.id = None;
+        }
         manifest.user_version = None;
         manifest.author = None;
         manifest.entrypoint = None;
 
-        // let get_entrypoint_mock = mock_server.mock(|when, then| {
-        //     when.method(GET)
-        //         .path("/v4.1/edge-apps/installations")
-        //         .header("Authorization", "Token token")
-        //         .header(
-        //             "user-agent",
-        //             format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-        //         )
-        //         .query_param("id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEB")
-        //         .query_param("select", "entrypoint");
-        //     then.status(200).json_body(json!([{"entrypoint": null}]));
-        // });
-        // "v4.1/edge-apps/versions?select=user_version,description,icon,author,entrypoint&app_id=eq.{}&order=revision.desc&limit=1",
         let last_versions_mock = mock_server.mock(|when, then| {
             when.method(GET)
                 .path("/v4.1/edge-apps/versions")
@@ -1403,347 +1402,14 @@ mod tests {
         let mut file = File::create(temp_dir.path().join("index.html")).unwrap();
         write!(file, "test").unwrap();
 
-        let result = command.deploy(
-            None,
-            Some(temp_dir.path().to_str().unwrap().to_string()),
-            Some(true),
-        );
-
-        // get_entrypoint_mock.assert();
-        last_versions_mock.assert_calls(2);
-        assets_mock.assert();
-        file_tree_from_version_mock.assert();
-        settings_mock.assert();
-        create_version_mock.assert();
-        settings_mock_create.assert();
-        settings_mock_patch.assert();
-        settings_mock_delete.assert();
-        upload_assets_mock.assert();
-        finished_processing_mock.assert();
-        publish_mock.assert();
-        copy_assets_mock.assert();
-        get_version_mock.assert();
-        promote_mock.assert();
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_deploy_with_explicit_app_id_and_no_manifest_id_should_send_correct_requests() {
-        let (temp_dir, command, mock_server, _manifest, _instance_manifest) =
-            prepare_edge_apps_test(false, false);
-
-        let mut manifest = create_edge_app_manifest_for_test(vec![
-            Setting {
-                name: "asetting".to_string(),
-                type_: SettingType::String,
-                title: Some("atitle".to_string()),
-                optional: false,
-                default_value: Some("".to_string()),
-                is_global: false,
-                help_text: "help text".to_string(),
-            },
-            Setting {
-                name: "nsetting".to_string(),
-                type_: SettingType::String,
-                title: Some("ntitle".to_string()),
-                optional: false,
-                default_value: Some("".to_string()),
-                is_global: false,
-                help_text: "help text".to_string(),
-            },
-        ]);
-
-        manifest.id = None;
-        manifest.user_version = None;
-        manifest.author = None;
-        manifest.entrypoint = None;
-
-        let last_versions_mock = mock_server.mock(|when, then| {
-            when.method(GET)
-                .path("/v4.1/edge-apps/versions")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .query_param(
-                    "select",
-                    "user_version,description,icon,author,homepage_url,categories,revision,ready_signal",
-                )
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("order", "revision.desc")
-                .query_param("limit", "1");
-            then.status(200).json_body(json!([
-                {
-                    "user_version": "1",
-                    "description": "desc",
-                    "icon": "icon",
-                    "author": "author",
-                    "homepage_url": "homepage_url",
-                    "categories": [],
-                    "ready_signal": false,
-                    "revision": 7,
-                }
-            ]));
-        });
-
-        let assets_mock = mock_server.mock(|when, then| {
-            when.method(GET)
-                .path("/v4/assets")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .query_param("select", "signature")
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("app_revision", "eq.7")
-                .query_param("type", "eq.edge-app-file");
-            then.status(200).json_body(json!([{"signature": "sig"}]));
-        });
-
-        let file_tree_from_version_mock = mock_server.mock(|when, then| {
-            when.method(GET)
-                .path("/v4/edge-apps/versions")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("revision", "eq.7")
-                .query_param("select", "file_tree");
-            then.status(200).json_body(json!([{"index.html": "sig"}]));
-        });
-
-        let settings_mock = mock_server.mock(|when, then| {
-                when.method(GET)
-                    .path("/v4.1/edge-apps/settings")
-                    .header("Authorization", "Token token")
-                    .header(
-                        "user-agent",
-                        format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                    )
-                    .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                    .query_param("select", "name,type,default_value,optional,title,help_text")
-                    .query_param("order", "name.asc");
-                then.status(200).json_body(json!([{
-                    "name": "nsetting".to_string(),
-                    "type": SettingType::String,
-                    "default_value": "5".to_string(),
-                    "title": "ntitle".to_string(),
-                    "optional": true,
-                    "help_text": "For how long to display the map overlay every time the rover has moved to a new position.".to_string(),
-                    "is_global": false,
-                }, {
-                    "name": "isetting".to_string(),
-                    "type": SettingType::String,
-                    "default_value": "5".to_string(),
-                    "title": null,
-                    "optional": true,
-                    "help_text": "Some text".to_string(),
-                    "is_global": false,
-                }]));
-            });
-
-        let create_version_mock = mock_server.mock(|when, then| {
-                when.method(POST)
-                    .path("/v4/edge-apps/versions")
-                    .header("Authorization", "Token token")
-                    .header(
-                        "user-agent",
-                        format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                    )
-                    .json_body(json!({
-                        "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                        "description": "asdf",
-                        "icon": "asdf",
-                        "homepage_url": "asdfasdf",
-                        "categories": ["Utilities", "Dashboards"],
-                        "file_tree": {
-                            "index.html": "0a209f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08122086cebd0c365d241e32d5b0972c07aae3a8d6499c2a9471aa85943a35577200021a180a14a94a8fe5ccb19ba61c4c0873d391e987982fbbd31000"
-                        },
-                        "ready_signal": false,
-                    }));
-                then.status(201).json_body(json!([{"revision": 8}]));
-            });
-
-        let settings_mock_create = mock_server.mock(|when, then| {
-            when.method(POST)
-                .path("/v4.1/edge-apps/settings")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .json_body(json!({
-                    "name": "asetting",
-                    "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                    "type": "string",
-                    "default_value": "",
-                    "title": "atitle",
-                    "optional": false,
-                    "help_text": {
-                        "schema_version": 1,
-                        "properties": {
-                            "help_text": "help text",
-                            "display_order": 0,
-                        },
-                    },
-                }));
-            then.status(201).json_body(json!(
-            [{
-                "name": "asetting",
-                "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                "type": "string",
-                "default_value": "",
-                "title": "atitle",
-                "optional": false,
-                "help_text": "help text",
-            }]));
-        });
-
-        let settings_mock_patch = mock_server.mock(|when, then| {
-            when.method(PATCH)
-                .path("/v4.1/edge-apps/settings")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("name", "eq.nsetting")
-                .json_body(json!({
-                    "name": "nsetting",
-                    "type": "string",
-                    "default_value": "",
-                    "title": "ntitle",
-                    "optional": false,
-                    "help_text": {
-                        "schema_version": 1,
-                        "properties": {
-                            "help_text": "help text",
-                            "display_order": 1,
-                        },
-                    },
-                }));
-            then.status(200).json_body(json!(
-            [{
-                "name": "nsetting",
-                "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                "type": "string",
-                "default_value": "",
-                "title": "ntitle",
-                "optional": false,
-                "help_text": "help text",
-            }]));
-        });
-
-        let settings_mock_delete = mock_server.mock(|when, then| {
-            when.method(DELETE)
-                .path("/v4.1/edge-apps/settings")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("name", "eq.isetting");
-            then.status(204).json_body(json!({}));
-        });
-
-        let copy_assets_mock = mock_server.mock(|when, then| {
-                when.method(POST)
-                    .path("/v4/edge-apps/copy-assets")
-                    .header("Authorization", "Token token")
-                    .header(
-                        "user-agent",
-                        format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                    ).json_body(json!({
-                        "app_id": "01H2QZ6Z8WXWNDC0KQ198XCZEW",
-                        "revision": 8,
-                        "signatures": ["0a209f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08122086cebd0c365d241e32d5b0972c07aae3a8d6499c2a9471aa85943a35577200021a180a14a94a8fe5ccb19ba61c4c0873d391e987982fbbd31000"]
-                    }));
-                then.status(201).json_body(json!([]));
-            });
-
-        let upload_assets_mock = mock_server.mock(|when, then| {
-            when.method(POST).path("/v4/assets");
-            then.status(201).body("");
-        });
-        let finished_processing_mock = mock_server.mock(|when, then| {
-            when.method(GET)
-                .path("/v4/assets")
-                .query_param("select", "status,processing_error,title")
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("app_revision", "eq.8")
-                .query_param("status", "neq.finished");
-            then.status(200).json_body(json!([]));
-        });
-
-        let publish_mock = mock_server.mock(|when, then| {
-            when.method(PATCH)
-                .path("/v4/edge-apps/versions")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("revision", "eq.8")
-                .json_body(json!({"published": true }));
-            then.status(200);
-        });
-
-        let get_version_mock = mock_server.mock(|when, then| {
-            when.method(GET)
-                .path("/v4/edge-apps/versions")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .query_param("select", "revision")
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("revision", "eq.8");
-
-            then.status(200).json_body(json!([
-                {
-                    "revision": 8,
-                }
-            ]));
-        });
-
-        let promote_mock = mock_server.mock(|when, then| {
-            when.method(PATCH)
-                .path("/v4/edge-apps/channels")
-                .header("Authorization", "Token token")
-                .header(
-                    "user-agent",
-                    format!("screenly-cli {}", env!("CARGO_PKG_VERSION")),
-                )
-                .query_param("app_id", "eq.01H2QZ6Z8WXWNDC0KQ198XCZEW")
-                .query_param("channel", "eq.stable")
-                .query_param("select", "channel,app_revision")
-                .json_body(json!({
-                    "app_revision": 8,
-                }));
-            then.status(200).json_body(json!([
-                {
-                    "channel": "stable",
-                    "app_revision": 8
-                }
-            ]));
-        });
-
-        EdgeAppManifest::save_to_file(&manifest, temp_dir.path().join("screenly.yml").as_path())
-            .unwrap();
-        let mut file = File::create(temp_dir.path().join("index.html")).unwrap();
-        write!(file, "test").unwrap();
+        let app_id = if id_in_manifest {
+            None
+        } else {
+            Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string())
+        };
 
         let result = command.deploy(
-            Some("01H2QZ6Z8WXWNDC0KQ198XCZEW".to_string()),
+            app_id,
             Some(temp_dir.path().to_str().unwrap().to_string()),
             Some(true),
         );


### PR DESCRIPTION
## Summary
- Folds `test_deploy_should_send_correct_requests` and `test_deploy_with_explicit_app_id_and_no_manifest_id_should_send_correct_requests` into a single shared helper, `run_deploy_should_send_correct_requests_test(id_in_manifest: bool)`, called with `true` and `false`.
- Addresses the non-blocking nit from https://github.com/Screenly/cli/pull/315#pullrequestreview-5098436444

## Test plan
- [x] `cargo build`
- [x] `cargo test` (only known pre-existing unrelated failure: `authentication::tests::test_read_token_correct_token_is_returned`)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`