### PR TITLE
Stop a blank line in .ignore from excluding the whole Edge App

### DIFF
--- a/src/commands/edge_app/utils.rs
+++ b/src/commands/edge_app/utils.rs
@@ -64,6 +64,10 @@ impl FileChanges {
 }
 
 fn is_included(entry: &DirEntry, ignore: &Ignorer) -> bool {
+    if entry.depth() == 0 {
+        return true;
+    }
+
     let exclusion_list = ["screenly.js", "screenly.yml", ".ignore", "instance.yml"];
     if exclusion_list.contains(&entry.file_name().to_str().unwrap_or_default()) {
         return false;
@@ -738,7 +742,7 @@ mod tests {
             .unwrap();
         File::create(dir_path.join(".ignore"))
             .unwrap()
-            .write_all(b"file2.txt")
+            .write_all(b"file2.txt\n\n")
             .unwrap();
         File::create(dir_path.join("instance.yml"))
             .unwrap()

--- a/src/commands/ignorer.rs
+++ b/src/commands/ignorer.rs
@@ -19,6 +19,9 @@ impl Ignorer {
 
             for line in content.lines() {
                 let pattern = line.trim();
+                if pattern.is_empty() {
+                    continue;
+                }
                 if pattern.ends_with('/') {
                     patterns.push(format!("^{}.*$", regex::escape(pattern)));
                 } else if pattern.contains('*') {
@@ -76,6 +79,21 @@ mod tests {
 
         assert!(ignorer.is_ignored(Path::new("file_to_ignore.txt")));
         assert!(!ignorer.is_ignored(Path::new("other_file.txt")));
+    }
+
+    #[test]
+    fn test_ignore_when_file_has_a_blank_line_should_not_ignore_the_root() {
+        let dir = tempdir().unwrap();
+
+        File::create(dir.path().join(".ignore"))
+            .unwrap()
+            .write_all(b"node_modules/\n\n")
+            .unwrap();
+
+        let ignorer = Ignorer::new(dir.path()).unwrap();
+
+        assert!(!ignorer.is_ignored(dir.path()));
+        assert!(ignorer.is_ignored(&dir.path().join("node_modules/react")));
     }
 
     #[test]

--- a/src/commands/ignorer.rs
+++ b/src/commands/ignorer.rs
@@ -82,7 +82,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ignore_when_file_has_a_blank_line_should_not_ignore_the_root() {
+    fn test_ignore_when_file_has_blank_line_should_not_ignore_root() {
         let dir = tempdir().unwrap();
 
         File::create(dir.path().join(".ignore"))


### PR DESCRIPTION
A blank line in `.ignore` became the regex pattern `^$`. `collect_paths_for_upload` walks with `WalkDir::new(root).filter_entry(is_included)`, and walkdir yields the root directory itself as the first entry — `Ignorer::is_ignored` strips the base path off it, leaving the empty string, which `^$` matches. Rejecting a directory in `filter_entry` prunes its whole subtree, so the walk ended before it started and the deploy collected zero files. The server then rejects the deploy with `index.html is required`.

Any editor that leaves a trailing newline on the file produces this, so it is easy to hit and gives no hint where the problem is. A single trailing `\n` is harmless — `str::lines` yields no empty item for it — but `\n\n` is enough.

Two changes:

- Blank (and whitespace-only) lines are skipped when patterns are built. An empty pattern has no meaning in any ignore syntax.
- `is_included` exempts the walk root, so no future pattern that happens to match the empty string can prune the whole tree again.
